### PR TITLE
Use built-in Django async queryset methods instead of `sync_to_async`

### DIFF
--- a/aqueduct/gateway/tests/test_endpoints.py
+++ b/aqueduct/gateway/tests/test_endpoints.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import ClassVar
 from unittest.mock import patch
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TransactionTestCase, override_settings
@@ -665,7 +665,7 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
         self.assertTrue(full_content, "Streamed content should not be empty.")
 
         # Check that the database contains one request and endpoint matches
-        requests = await sync_to_async(lambda: list(Request.objects.all()))()
+        requests = [r async for r in Request.objects.all()]
         self.assertEqual(
             len(requests), 1, "There should be exactly one request after streaming chat completion."
         )
@@ -693,7 +693,7 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
         - Request should appear in usage dashboard
         """
         # Clear existing requests
-        await sync_to_async(Request.objects.all().delete)()
+        await Request.objects.all().adelete()
 
         response = await self._send_chat_completion_streaming(self.MESSAGES)
 
@@ -705,7 +705,7 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
         )
 
         # THIS IS THE CRITICAL CHECK: Verify streaming timeout request was logged
-        requests = await sync_to_async(lambda: list(Request.objects.all()))()
+        requests = [r async for r in Request.objects.all()]
         self.assertGreater(
             len(requests),
             0,
@@ -997,7 +997,7 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
         self.assertIsInstance(result["greeting"], str)
         self.assertIsInstance(result["count"], int)
 
-        requests = await sync_to_async(lambda: list(Request.objects.all()))()
+        requests = [r async for r in Request.objects.all()]
         self.assertEqual(
             len(requests),
             1,

--- a/aqueduct/gateway/tests/test_mcp.py
+++ b/aqueduct/gateway/tests/test_mcp.py
@@ -538,7 +538,7 @@ class MCPServerExclusionTest(MCPLiveServerTestCase):
         # Get org and add exclusion
         from management.models import Org
 
-        org = await sync_to_async(Org.objects.get)(name="E060")
+        org = await Org.objects.aget(name="E060")
         await sync_to_async(org.add_excluded_mcp_server)("test-server")
 
         # Try to access the MCP server - should get 404
@@ -560,22 +560,22 @@ class MCPServerExclusionTest(MCPLiveServerTestCase):
         # Get team and add exclusion
         from management.models import ServiceAccount, Team, Token
 
-        team = await sync_to_async(Team.objects.get)(name="Whale")
+        team = await Team.objects.aget(name="Whale")
         await sync_to_async(team.add_excluded_mcp_server)("test-server")
 
         # Create a service account for the team
-        service_account = await sync_to_async(ServiceAccount.objects.create)(
+        service_account = await ServiceAccount.objects.acreate(
             team=team, name="Test Service Account"
         )
 
         # Create a token for the service account
         from gateway.tests.utils.base import GatewayIntegrationTestCase
 
-        token = await sync_to_async(Token.objects.get)(
+        token = await Token.objects.aget(
             key_hash=Token._hash_key(GatewayIntegrationTestCase.AQUEDUCT_ACCESS_TOKEN)
         )
         token.service_account = service_account
-        await sync_to_async(token.save)()
+        await token.asave()
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -587,8 +587,8 @@ class MCPServerExclusionTest(MCPLiveServerTestCase):
 
         # Clean up
         token.service_account = None
-        await sync_to_async(token.save)()
-        await sync_to_async(service_account.delete)()
+        await token.asave()
+        await service_account.adelete()
         await sync_to_async(team.remove_excluded_mcp_server)("test-server")
 
     @async_to_sync
@@ -599,8 +599,8 @@ class MCPServerExclusionTest(MCPLiveServerTestCase):
         user_model = get_user_model()
 
         # Get user and their profile
-        user = await sync_to_async(user_model.objects.get)(username="Me")
-        profile = await sync_to_async(lambda: user.profile)()
+        user = await user_model.objects.select_related("profile").aget(username="Me")
+        profile = user.profile
 
         # Add exclusion to user profile
         await sync_to_async(profile.add_excluded_mcp_server)("test-server")
@@ -633,10 +633,10 @@ class MCPServerExclusionTest(MCPLiveServerTestCase):
         )
 
         # Setup: Org excludes test-server, user has merge enabled (default)
-        org = await sync_to_async(Org.objects.get)(name="E060")
+        org = await Org.objects.aget(name="E060")
         await sync_to_async(org.add_excluded_mcp_server)("test-server")
 
-        user = await sync_to_async(user_model.objects.get)(username="Me")
+        user = await user_model.objects.aget(username="Me")
         profile = await sync_to_async(lambda: user.profile)()
 
         # Verify merge_mcp_server_exclusion_lists is True by default
@@ -653,7 +653,7 @@ class MCPServerExclusionTest(MCPLiveServerTestCase):
 
         # Now disable merging at user level
         profile.merge_mcp_server_exclusion_lists = False
-        await sync_to_async(profile.save)()
+        await profile.asave()
 
         # Check that test-server is NOT in exclusion list (merge disabled, user has no exclusions)
         exclusion_list = await sync_to_async(token.mcp_server_exclusion_list)()
@@ -665,7 +665,7 @@ class MCPServerExclusionTest(MCPLiveServerTestCase):
 
         # Clean up
         profile.merge_mcp_server_exclusion_lists = True
-        await sync_to_async(profile.save)()
+        await profile.asave()
         await sync_to_async(org.remove_excluded_mcp_server)("test-server")
 
     @async_to_sync

--- a/aqueduct/gateway/tests/test_responses.py
+++ b/aqueduct/gateway/tests/test_responses.py
@@ -54,7 +54,7 @@ class ResponsesIntegrationTest(GatewayIntegrationTestCase):
         self.assertIn("output", response_json)
         self.assertIsInstance(response_json["output"], list)
 
-        requests = await sync_to_async(list)(Request.objects.all())
+        requests = [r async for r in Request.objects.all()]
         self.assertEqual(
             len(requests), 1, "There should be exactly one request after response creation."
         )
@@ -182,7 +182,7 @@ class ResponsesIntegrationTest(GatewayIntegrationTestCase):
         self.assertIn("Hello", full_content, "Streaming response should contain greeting.")
 
         # Check that the database contains one request and endpoint matches
-        requests = await sync_to_async(lambda: list(Request.objects.all()))()
+        requests = [r async for r in Request.objects.all()]
         self.assertEqual(
             len(requests),
             1,
@@ -645,18 +645,12 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         token.service_account = None
         token.user = MagicMock()
 
-        mock_vs1 = MagicMock()
-        mock_vs1.id = "vs_remote_abc"
-
-        mock_vs2 = MagicMock()
-        mock_vs2.id = "vs_remote_def"
-
         tool = {"type": "file_search", "vector_store_ids": ["vs_remote_abc", "vs_remote_def"]}
         pydantic_model = {"tools": [tool]}
         kwargs = {"token": token, "pydantic_model": pydantic_model}
 
         mock_queryset = MagicMock()
-        mock_queryset.count = MagicMock(return_value=2)
+        mock_queryset.acount = AsyncMock(return_value=2)
         mock_vector_store_class.objects.filter.return_value = mock_queryset
 
         decorated_func = check_tool_availability(mock_view_func)
@@ -693,15 +687,12 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         token.service_account = mock_service_account
         token.user = MagicMock()
 
-        mock_vs = MagicMock()
-        mock_vs.id = "vs_remote_abc"
-
         tool = {"type": "file_search", "vector_store_ids": ["vs_remote_abc"]}
         pydantic_model = {"tools": [tool]}
         kwargs = {"token": token, "pydantic_model": pydantic_model}
 
         mock_queryset = MagicMock()
-        mock_queryset.count = MagicMock(return_value=1)
+        mock_queryset.acount = AsyncMock(return_value=1)
         mock_vector_store_class.objects.filter.return_value = mock_queryset
 
         decorated_func = check_tool_availability(mock_view_func)
@@ -735,7 +726,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         kwargs = {"token": token, "pydantic_model": pydantic_model}
 
         mock_queryset = MagicMock()
-        mock_queryset.count = MagicMock(return_value=0)
+        mock_queryset.acount = AsyncMock(return_value=0)
         mock_vector_store_class.objects.filter.return_value = mock_queryset
 
         decorated_func = check_tool_availability(mock_view_func)

--- a/aqueduct/gateway/tests/test_tts_stt.py
+++ b/aqueduct/gateway/tests/test_tts_stt.py
@@ -2,7 +2,6 @@ import io
 import json
 from pathlib import Path
 
-from asgiref.sync import sync_to_async
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 
@@ -46,7 +45,7 @@ class SpeechEndpointTest(GatewayTTSSTTestCase):
         self.assertGreater(len(audio_data), 0, "Should receive audio data")
 
         # Check that the database contains one request
-        requests = await sync_to_async(list)(Request.objects.all())
+        requests = [r async for r in Request.objects.all()]
         self.assertEqual(
             len(requests), 1, "There should be exactly one request after speech generation."
         )
@@ -410,7 +409,7 @@ class TTSSTTLifecycleTest(GatewayTTSSTTestCase):
         self.assertGreater(len(audio_data), 0, "TTS should generate audio data")
 
         # Check TTS request was logged
-        tts_requests = await sync_to_async(list)(Request.objects.filter(path__contains="speech"))
+        tts_requests = [r async for r in Request.objects.filter(path__contains="speech")]
         self.assertEqual(len(tts_requests), 1, "There should be exactly one TTS request.")
         tts_request = tts_requests[0]
         self.assertIsNotNone(tts_request.token_usage)
@@ -434,15 +433,13 @@ class TTSSTTLifecycleTest(GatewayTTSSTTestCase):
         self.assertGreater(len(transcribed_text), 0, "Transcribed text should not be empty")
 
         # Check STT request was logged
-        stt_requests = await sync_to_async(list)(
-            Request.objects.filter(path__contains="transcriptions")
-        )
+        stt_requests = [r async for r in Request.objects.filter(path__contains="transcriptions")]
         self.assertEqual(len(stt_requests), 1, "There should be exactly one STT request.")
         stt_request = stt_requests[0]
         self.assertIsNotNone(stt_request.token_usage)
 
         # Verify the complete lifecycle: total requests should be 2 (TTS + STT)
-        total_requests = await sync_to_async(list)(Request.objects.all())
+        total_requests = [r async for r in Request.objects.all()]
         self.assertEqual(
             len(total_requests), 2, "There should be exactly two requests in the lifecycle."
         )
@@ -538,12 +535,10 @@ class TTSSTTLifecycleTest(GatewayTTSSTTestCase):
                 )
 
                 # Verify requests were logged
-                tts_requests = await sync_to_async(list)(
-                    Request.objects.filter(path__contains="speech")
-                )
-                stt_requests = await sync_to_async(list)(
-                    Request.objects.filter(path__contains="transcriptions")
-                )
+                tts_requests = [r async for r in Request.objects.filter(path__contains="speech")]
+                stt_requests = [
+                    r async for r in Request.objects.filter(path__contains="transcriptions")
+                ]
                 self.assertEqual(
                     len(tts_requests), 1, f"There should be one TTS request for voice {voice}"
                 )

--- a/aqueduct/gateway/tests/utils/mcp.py
+++ b/aqueduct/gateway/tests/utils/mcp.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import ClassVar
 
 import httpx
-from asgiref.sync import sync_to_async
 from channels.testing import ChannelsLiveServerTestCase
 from daphne.testing import DaphneProcess
 from django.test import override_settings
@@ -23,6 +22,7 @@ from gateway.tests.utils.test_runner import (
     get_shared_mcp_server_process,
     set_shared_mcp_server,
 )
+from management.models import Request
 from mock_api.helpers import get_available_port
 
 logger = logging.getLogger(__name__)
@@ -142,11 +142,9 @@ class MCPLiveServerTestCase(ChannelsLiveServerTestCase):
             yield session
 
     async def assert_request_logged(self, n: int = 1):
-        from management.models import Request
-
         # Check that (only) initialize request was logged
 
-        mcp_requests = await sync_to_async(Request.objects.count)()
+        mcp_requests = await Request.objects.acount()
         self.assertEqual(mcp_requests, n, f"There should be exactly {n} logged MCP request.")
 
     @classmethod

--- a/aqueduct/gateway/views/batches.py
+++ b/aqueduct/gateway/views/batches.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
 from django.http import JsonResponse
@@ -65,28 +64,16 @@ async def batches(
     # Check batch limit before creating batch (for upstream quota management)
     max_batches = settings.MAX_USER_BATCHES
     if token.service_account:
-        active_count = await sync_to_async(
-            Batch.objects.filter(
-                token__service_account__team=token.service_account.team,
-                status__in=[
-                    BatchStatus.VALIDATING,
-                    BatchStatus.IN_PROGRESS,
-                    BatchStatus.CANCELLING,
-                ],
-            ).count
-        )()
+        active_count = await Batch.objects.filter(
+            token__service_account__team=token.service_account.team,
+            status__in=[BatchStatus.VALIDATING, BatchStatus.IN_PROGRESS, BatchStatus.CANCELLING],
+        ).acount()
         limit = settings.MAX_TEAM_BATCHES
     else:
-        active_count = await sync_to_async(
-            Batch.objects.filter(
-                token__user=token.user,
-                status__in=[
-                    BatchStatus.VALIDATING,
-                    BatchStatus.IN_PROGRESS,
-                    BatchStatus.CANCELLING,
-                ],
-            ).count
-        )()
+        active_count = await Batch.objects.filter(
+            token__user=token.user,
+            status__in=[BatchStatus.VALIDATING, BatchStatus.IN_PROGRESS, BatchStatus.CANCELLING],
+        ).acount()
         limit = max_batches
 
     if active_count >= limit:
@@ -135,7 +122,7 @@ async def batches(
         if remote_batch.request_counts
         else {},
     )
-    await sync_to_async(batch_obj.save)()
+    await batch_obj.asave()
 
     # Return upstream response directly (IDs already match)
     response_data = remote_batch.model_dump()
@@ -241,7 +228,7 @@ async def batch_cancel(
         batch_obj.cancelling_at = remote_batch.cancelling_at
     if remote_batch.cancelled_at:
         batch_obj.cancelled_at = remote_batch.cancelled_at
-    await sync_to_async(batch_obj.save)()
+    await batch_obj.asave()
 
     # Build response from upstream data, ensuring file IDs match our local records
     response_data = remote_batch.model_dump()

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -857,15 +857,13 @@ async def _validate_file_search_tool(token: Token, tool: ToolParam) -> ViewResul
     unique_vs_ids = list(set(vector_store_ids))
     # Verify ownership - users can only use their own vector stores
     if token.service_account:
-        vs_count = await sync_to_async(
-            VectorStore.objects.filter(
-                id__in=unique_vs_ids, token__service_account__team=token.service_account.team
-            ).count
-        )()
+        vs_count = await VectorStore.objects.filter(
+            id__in=unique_vs_ids, token__service_account__team=token.service_account.team
+        ).acount()
     else:
-        vs_count = await sync_to_async(
-            VectorStore.objects.filter(id__in=unique_vs_ids, token__user=token.user).count
-        )()
+        vs_count = await VectorStore.objects.filter(
+            id__in=unique_vs_ids, token__user=token.user
+        ).acount()
 
     if vs_count != len(unique_vs_ids):
         return error_response("One or more vector stores not found", status=404)

--- a/aqueduct/gateway/views/files.py
+++ b/aqueduct/gateway/views/files.py
@@ -3,7 +3,6 @@ import json
 from datetime import timedelta
 from typing import Any, Literal, Optional
 
-from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
 from django.db.models import Sum
@@ -105,7 +104,7 @@ async def sync_batch_file_if_needed(
     # (e.g., two GET /batches/{id} requests polling the same completed batch).
     local_expires_at = calculate_expires_at(remote_file.expires_at)
 
-    file_obj, _ = await sync_to_async(FileObject.objects.get_or_create)(
+    file_obj, _ = await FileObject.objects.aget_or_create(
         id=remote_file.id,
         token=token,
         defaults={
@@ -122,7 +121,7 @@ async def sync_batch_file_if_needed(
     # Update batch record with linked file if batch_obj provided
     if batch_obj:
         setattr(batch_obj, field_name, file_obj)
-        await sync_to_async(batch_obj.save)(update_fields=[field_name])
+        await batch_obj.asave(update_fields=[field_name])
 
     return file_obj
 
@@ -241,7 +240,7 @@ async def files(
         preview=file_preview or "",
         upstream_url=settings.AQUEDUCT_FILES_API_URL or "",
     )
-    await sync_to_async(file_obj.save)()
+    await file_obj.asave()
 
     # Return response with upstream ID
     response_data = file_obj.model.model_dump(exclude_none=True, exclude_unset=True)
@@ -292,7 +291,7 @@ async def file(
     await file_obj.adelete_upstream(client)
 
     # Delete local record
-    await sync_to_async(file_obj.delete)()
+    await file_obj.adelete()
 
     # Return response with upstream ID
     response_data = {"id": file_id, "object": "file", "deleted": True}

--- a/aqueduct/gateway/views/vector_store_file_batches.py
+++ b/aqueduct/gateway/views/vector_store_file_batches.py
@@ -158,7 +158,7 @@ async def vector_store_file_batches(
         ),
         created_at=int(now.timestamp()),
     )
-    await sync_to_async(batch_obj.save)()
+    await batch_obj.asave()
 
     # Create VectorStoreFile records for each file in the batch
     # Use transaction and check file limit
@@ -307,7 +307,7 @@ async def vector_store_file_batch_cancel(
     batch_obj.status = remote_batch.status or VectorStoreFileBatchStatus.CANCELLED
     if hasattr(remote_batch, "file_counts") and remote_batch.file_counts:
         batch_obj.file_counts = remote_batch.file_counts.model_dump(mode="json")
-    await sync_to_async(batch_obj.save)()
+    await batch_obj.asave()
 
     # Handle orphaned VectorStoreFile records when batch is cancelled
     await mark_orphaned_files(

--- a/aqueduct/gateway/views/vector_store_files.py
+++ b/aqueduct/gateway/views/vector_store_files.py
@@ -245,7 +245,7 @@ async def vector_store_file(
     await vs_file_obj.adelete_upstream(client)
 
     # Delete local record
-    await sync_to_async(vs_file_obj.delete)()
+    await vs_file_obj.adelete()
 
     # Return response with upstream ID
     response_data = {"id": file_id, "object": "vector_store.file.deleted", "deleted": True}

--- a/aqueduct/gateway/views/vector_stores.py
+++ b/aqueduct/gateway/views/vector_stores.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
 from django.db.models import Count, Q
@@ -114,16 +113,12 @@ async def vector_stores(
     # Check user/team limits before creating
     if token.service_account:
         limit = settings.MAX_TEAM_VECTOR_STORES
-        active_count = await sync_to_async(
-            VectorStore.objects.filter(
-                token__service_account__team=token.service_account.team
-            ).count
-        )()
+        active_count = await VectorStore.objects.filter(
+            token__service_account__team=token.service_account.team
+        ).acount()
     else:
         limit = settings.MAX_USER_VECTOR_STORES
-        active_count = await sync_to_async(
-            VectorStore.objects.filter(token__user=token.user).count
-        )()
+        active_count = await VectorStore.objects.filter(token__user=token.user).acount()
 
     if active_count >= limit:
         return error_response(f"Vector store limit reached ({limit})", status=403)
@@ -153,7 +148,7 @@ async def vector_stores(
         metadata=pydantic_model.get("metadata"),
         upstream_url=settings.AQUEDUCT_FILES_API_URL or "",
     )
-    await sync_to_async(vs_obj.save)()
+    await vs_obj.asave()
 
     # Return upstream response directly (ID already matches)
     response_data = remote_vs.model_dump(mode="json")
@@ -229,7 +224,7 @@ async def vector_store(
                 setattr(vs_obj, field, value)
             vs_obj.status = remote_vs.status
             vs_obj.usage_bytes = remote_vs.usage_bytes
-            await sync_to_async(vs_obj.save)()
+            await vs_obj.asave()
 
             # Return upstream response directly (ID already matches)
             response_data = remote_vs.model_dump(mode="json")
@@ -249,7 +244,7 @@ async def vector_store(
     deleted_id = vs_obj.id
 
     # Delete local record
-    await sync_to_async(vs_obj.delete)()
+    await vs_obj.adelete()
 
     # Return with upstream ID
     return JsonResponse(


### PR DESCRIPTION
I've noticed that we used the same trick with `sync_to_async(list)(...<query>...)` in other places, and also realised that some of the `sync_to_async` calls on Queryset methods are unnecessary, because Django has asynchronous versions of those methods.