### PR TITLE
Normalize reasoning fields

### DIFF
--- a/aqueduct/gateway/tests/test_endpoints.py
+++ b/aqueduct/gateway/tests/test_endpoints.py
@@ -1021,6 +1021,151 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
             req.output_tokens, 0, "output_tokens should be > 0 (streaming schema generation)"
         )
 
+    def test_reasoning_content_adds_reasoning_non_streaming(self):
+        """Non-streaming: 'reasoning_content' in message → 'reasoning' is added."""
+        mock_resp = MockConfig(
+            response_data=ModelResponse(
+                id="chatcmpl-reasoning-test",
+                created=1768397207,
+                model="gpt-4.1-nano-2025-04-14",
+                object="chat.completion",
+                choices=[
+                    Choices(
+                        finish_reason="stop",
+                        index=0,
+                        message=Message(
+                            content="Final answer",
+                            role="assistant",
+                            reasoning_content="Step-by-step reasoning...",
+                        ),
+                    )
+                ],
+                usage=Usage(
+                    completion_tokens=10,
+                    prompt_tokens=20,
+                    total_tokens=30,
+                    completion_tokens_details={"reasoning_tokens": 15},
+                ),
+            ).model_dump()
+        )
+        with self.mock_server.patch_external_api("chat/completions", mock_resp):
+            response = self._send_chat_completion(self.MESSAGES)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        message = data["choices"][0]["message"]
+        self.assertEqual(message["reasoning_content"], "Step-by-step reasoning...")
+        self.assertEqual(message["reasoning"], "Step-by-step reasoning...")
+
+    def test_reasoning_adds_reasoning_content_non_streaming(self):
+        """Non-streaming: 'reasoning' in message → 'reasoning_content' is added."""
+        mock_resp = MockConfig(
+            response_data=ModelResponse(
+                id="chatcmpl-reasoning-test",
+                created=1768397207,
+                model="gpt-4.1-nano-2025-04-14",
+                object="chat.completion",
+                choices=[
+                    Choices(
+                        finish_reason="stop",
+                        index=0,
+                        message=Message(
+                            content="Final answer",
+                            role="assistant",
+                            reasoning="Deep chain of thought...",
+                        ),
+                    )
+                ],
+                usage=Usage(
+                    completion_tokens=10,
+                    prompt_tokens=20,
+                    total_tokens=30,
+                    completion_tokens_details={"reasoning_tokens": 12},
+                ),
+            ).model_dump()
+        )
+        with self.mock_server.patch_external_api("chat/completions", mock_resp):
+            response = self._send_chat_completion(self.MESSAGES)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        message = data["choices"][0]["message"]
+        self.assertEqual(message["reasoning"], "Deep chain of thought...")
+        self.assertEqual(message["reasoning_content"], "Deep chain of thought...")
+
+    def test_neither_reasoning_field_present_unchanged(self):
+        """Non-streaming: neither field present → response unchanged."""
+        mock_resp = MockConfig(
+            response_data=ModelResponse(
+                id="chatcmpl-no-reasoning",
+                created=1768397207,
+                model="gpt-4.1-nano-2025-04-14",
+                object="chat.completion",
+                choices=[
+                    Choices(
+                        finish_reason="stop",
+                        index=0,
+                        message=Message(content="Plain response, no reasoning.", role="assistant"),
+                    )
+                ],
+                usage=Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30),
+            ).model_dump()
+        )
+        with self.mock_server.patch_external_api("chat/completions", mock_resp):
+            response = self._send_chat_completion(self.MESSAGES)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        message = data["choices"][0]["message"]
+        self.assertNotIn("reasoning", message)
+        self.assertNotIn("reasoning_content", message)
+
+    async def test_reasoning_content_adds_reasoning_streaming(self):
+        """Streaming: 'reasoning_content' in delta → 'reasoning' is added to each chunk."""
+        _common = {
+            "id": "chatcmpl-stream-reasoning",
+            "created": 1768398242,
+            "model": "gpt-4.1-nano",
+            "object": "chat.completion.chunk",
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        stream_data = [
+            ModelResponse(
+                **_common,
+                choices=[
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "reasoning_content": "Let me think..."},
+                    }
+                ],
+            ).model_dump(),
+            ModelResponse(
+                **_common, choices=[{"index": 0, "delta": {"content": "The answer is 42."}}]
+            ).model_dump(),
+            ModelResponse(
+                **_common, choices=[{"index": 0, "delta": {}, "finish_reason": "stop"}]
+            ).model_dump(),
+        ]
+        mock_resp = MockStreamingConfig(response_data=convert_to_stream_data(stream_data))
+        with self.mock_server.patch_external_api("chat/completions", mock_resp):
+            request = self._build_chat_completion_request(self.MESSAGES, stream=True)
+            response = await self.async_client.post(**request, content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+        streamed_lines = await _read_streaming_response_lines(response)
+        # First chunk should have both reasoning and reasoning_content in delta
+        first_chunk = json.loads(streamed_lines[0])
+        delta = first_chunk["choices"][0]["delta"]
+        self.assertEqual(delta["reasoning_content"], "Let me think...")
+        self.assertEqual(delta["reasoning"], "Let me think...")
+
+        # Content-only chunk should be unchanged (no reasoning fields)
+        content_chunk = json.loads(streamed_lines[1])
+        content_delta = content_chunk["choices"][0]["delta"]
+        self.assertNotIn("reasoning", content_delta)
+        self.assertNotIn("reasoning_content", content_delta)
+
 
 class ListModelsIntegrationTest(GatewayIntegrationTestCase):
     def _send_model_list_request(self):

--- a/aqueduct/gateway/tests/test_endpoints.py
+++ b/aqueduct/gateway/tests/test_endpoints.py
@@ -774,9 +774,7 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
             400,
             f"Expected 400 Bad Request, got {response.status_code}: {response.content}",
         )
-        self.assertIn(
-            "There is no 'model_name' with this string", response.json()["error"]["message"]
-        )
+        self.assertIn("no healthy deployments for this model", response.json()["error"]["message"])
 
     def test_chat_completion_schema_generation(self):
         """

--- a/aqueduct/gateway/tests/test_tts_stt.py
+++ b/aqueduct/gateway/tests/test_tts_stt.py
@@ -74,9 +74,7 @@ class SpeechEndpointTest(GatewayTTSSTTestCase):
         self.assertEqual(
             response.status_code, 400, f"Expected 400 Bad Request, got {response.status_code}"
         )
-        self.assertIn(
-            "There is no 'model_name' with this string", response.json()["error"]["message"]
-        )
+        self.assertIn("no healthy deployments for this model", response.json()["error"]["message"])
 
     def test_speech_endpoint_missing_required_fields(self):
         """Test speech endpoint with missing required fields."""

--- a/aqueduct/gateway/views/chat_completions.py
+++ b/aqueduct/gateway/views/chat_completions.py
@@ -18,6 +18,7 @@ from .decorators import (
     check_model_availability,
     ensure_usage,
     log_request,
+    normalize_reasoning_fields,
     parse_body,
     process_file_content,
     resolve_alias,
@@ -38,6 +39,7 @@ from .utils import _get_token_usage, _openai_stream
 @resolve_alias
 @log_request
 @check_model_availability
+@normalize_reasoning_fields
 @catch_router_exceptions
 async def chat_completions(
     request: ASGIRequest,

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -5,11 +5,11 @@ import logging
 import re
 import sys
 import time
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Iterable
 from datetime import timedelta
 from functools import wraps
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import litellm
@@ -21,7 +21,7 @@ from django.core.cache import cache
 from django.core.files.uploadedfile import UploadedFile
 from django.core.handlers.asgi import ASGIRequest
 from django.db.models import Count, Sum
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.urls import reverse
 from django.utils import timezone
 from mcp.types import JSONRPCMessage
@@ -690,6 +690,88 @@ def catch_router_exceptions(view_func: AsyncView) -> AsyncView:
         except Exception as e:
             log.exception("Unexpected error - %s", _r(e))
             return error_response(_r(e), error_type="server_error", status=502)
+
+    return wrapper
+
+
+def _normalize_choice_message(message: dict[str, Any]) -> bool:
+    """Ensure both 'reasoning' and 'reasoning_content' are present if either exists.
+
+    Returns True if the message was modified.
+    """
+    reasoning = message.get("reasoning")
+    reasoning_content = message.get("reasoning_content")
+
+    if reasoning_content is not None and reasoning is None:
+        message["reasoning"] = reasoning_content
+        return True
+    if reasoning is not None and reasoning_content is None:
+        message["reasoning_content"] = reasoning
+        return True
+    return False
+
+
+def normalize_reasoning_fields(view_func: AsyncView) -> AsyncView:
+    """Normalize reasoning/reasoning_content fields in chat completion responses.
+
+    Ensures that if a response message contains either 'reasoning' or
+    'reasoning_content', both fields are present with the same value.
+    This provides compatibility for clients that expect one field name
+    or the other.
+
+    Handles both streaming and non-streaming responses.
+    """
+
+    @wraps(view_func)
+    async def wrapper(request: ASGIRequest, *args: Any, **kwargs: Any) -> ViewResult:
+        result = await view_func(request, *args, **kwargs)
+
+        if isinstance(result, StreamingHttpResponse):
+            original_stream = cast("AsyncIterator[bytes]", result.streaming_content)
+
+            async def normalized_stream() -> AsyncGenerator[str, None]:
+                async for chunk in original_stream:
+                    # Chunks may be bytes or str; normalize to str for parsing
+                    if isinstance(chunk, bytes):
+                        chunk_str = chunk.decode("utf-8")
+                    else:
+                        chunk_str = chunk
+
+                    if chunk_str.startswith("data: ") and not chunk_str.startswith("data: [DONE]"):
+                        try:
+                            data_str = chunk_str.removeprefix("data: ")
+                            data_str = data_str.rstrip("\n")
+                            chunk_data = json.loads(data_str)
+
+                            choices = chunk_data.get("choices", [])
+                            for choice in choices:
+                                # Streaming chunks use "delta"; final chunks use "message"
+                                message = choice.get("delta") or {}
+                                if message:
+                                    _normalize_choice_message(message)
+
+                            modified_chunk = f"data: {json.dumps(chunk_data)}\n\n"
+                        except (json.JSONDecodeError, UnicodeDecodeError):
+                            modified_chunk = chunk_str
+
+                    else:
+                        modified_chunk = chunk_str
+
+                    yield modified_chunk
+
+            result.streaming_content = normalized_stream()
+
+        elif isinstance(result, JsonResponse):
+            content = json.loads(result.content)
+            choices = content.get("choices", [])
+            for choice in choices:
+                message = choice.get("message", {})
+                if message:
+                    _normalize_choice_message(message)
+
+            result = JsonResponse(content, status=result.status_code)
+
+        return result
 
     return wrapper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "django-silk>=5.4.0",
     "django-tos>=1.1.0",
     "httpx>=0.28.1, <1",
-    "litellm==1.72.0",
+    "litellm==1.85.2",
     "mcp==1.25.0",
     "mozilla-django-oidc>=4.0.1",
     "openai==2.36.0",

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ wheels = [
 
 [[package]]
 name = "aqueduct"
-version = "0.1.14"
+version = "0.1.15"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },
@@ -196,7 +196,7 @@ requires-dist = [
     { name = "django-silk", specifier = ">=5.4.0" },
     { name = "django-tos", specifier = ">=1.1.0" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "litellm", specifier = "==1.72.0" },
+    { name = "litellm", specifier = "==1.85.2" },
     { name = "mcp", specifier = "==1.25.0" },
     { name = "mozilla-django-oidc", specifier = ">=4.0.1" },
     { name = "openai", specifier = "==2.36.0" },
@@ -1061,6 +1061,58 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1866,11 +1918,12 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.72.0"
+version = "1.85.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
+    { name = "fastuuid" },
     { name = "httpx" },
     { name = "importlib-metadata" },
     { name = "jinja2" },
@@ -1881,9 +1934,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/d3/f1a8c9c9ffdd3bab1bc410254c8140b1346f05a01b8c6b37c48b56abb4b0/litellm-1.72.0.tar.gz", hash = "sha256:135022b9b8798f712ffa84e71ac419aa4310f1d0a70f79dd2007f7ef3a381e43", size = 8082337, upload-time = "2025-06-01T02:12:54.203Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/fc/1d30a65cdc3a5370f974e4f571eb497d88243b6abd58269a635da0045bb4/litellm-1.85.2.tar.gz", hash = "sha256:4e8064db7aab0017d0a57fbbd203aa7afa0cf462ccbee4d1328edfa45c50d465", size = 15346880, upload-time = "2026-05-27T08:03:30.285Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/98/bec08f5a3e504013db6f52b5fd68375bd92b463c91eb454d5a6460e957af/litellm-1.72.0-py3-none-any.whl", hash = "sha256:88360a7ae9aa9c96278ae1bb0a459226f909e711c5d350781296d0640386a824", size = 7979630, upload-time = "2025-06-01T02:12:50.458Z" },
+    { url = "https://files.pythonhosted.org/packages/85/89/d8c1566085dcf2274374094abdee3b76b84623b46a0cf01115d078a7bd9d/litellm-1.85.2-py3-none-any.whl", hash = "sha256:16d6b63a2c78e1e250e54691f63669ab15c49e11ae6e0457462ac609c4a52352", size = 16980870, upload-time = "2026-05-27T08:03:26.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Ensures that if a response message contains either 'reasoning' or 'reasoning_content', both fields are present with the same value. This provides compatibility for clients that expect one field name or the other.