### PR TITLE
Replace undersores with hyphens in dc services and container names

### DIFF
--- a/aqueduct/locustfiles/.locust.env
+++ b/aqueduct/locustfiles/.locust.env
@@ -10,21 +10,21 @@ DATABASE_ENGINE=django.db.backends.postgresql
 POSTGRES_DB=aqueduct
 POSTGRES_USER=aqueduct
 POSTGRES_PASSWORD=aqueduct
-POSTGRES_HOST=locust_db
+POSTGRES_HOST=locust-db
 POSTGRES_PORT=5432
 
 # Django settings
-ALLOWED_HOSTS=localhost
+ALLOWED_HOSTS=localhost locust-web
 
 SILKY_ENABLED=false
 
 # OpenAI settings
 OPENAI_API_KEY=fake_openai_key
-OPENAI_BASE_URL=mock_api:45999
+OPENAI_BASE_URL=mock-api:45999
 
 # Further settings that have to be set for the app to function
 OIDC_OP_JWKS_ENDPOINT=https://example.com/application/o/example/jwks/
-CELERY_BROKER_URL=redis://locust_redis:6379/0
+CELERY_BROKER_URL=redis://locust-redis:6379/0
 
 # Files/Batches API Configuration
-AQUEDUCT_FILES_API_URL=http://mock_api:45999
+AQUEDUCT_FILES_API_URL=http://mock-api:45999

--- a/aqueduct/locustfiles/docker-compose-locust.yaml
+++ b/aqueduct/locustfiles/docker-compose-locust.yaml
@@ -1,10 +1,10 @@
 services:
 
-  mock_api:
+  mock-api:
     build:
       context: ../..
       dockerfile: ./aqueduct/locustfiles/Dockerfile
-    container_name: mock_api
+    container_name: mock-api
     command: python -m mock_api.mock_server --host 0.0.0.0 --port 45999 --delays
     volumes:
       - ./locust_router_config.yaml:/app/aqueduct/locust_router_config.yaml
@@ -13,24 +13,24 @@ services:
     env_file:
       - .locust.env
     depends_on:
-      locust_web:
+      locust-web:
         condition: service_started
 
-  locust_migrate:
+  locust-migrate:
     build:
       context: ../..
       dockerfile: ./aqueduct/locustfiles/Dockerfile
-    container_name: locust_django_migrate
+    container_name: locust-django-migrate
     command: python manage.py migrate
     env_file:
       - .locust.env
     depends_on:
-      - locust_db
+      - locust-db
 
-  locust_web:
+  locust-web:
     build:
       context: ../..
-    container_name: locust_django_app
+    container_name: locust-django-app
     command: |
       sh -c "python manage.py collectstatic --no-input &&
              python manage.py loaddata locustfiles/locust_fixture.json &&
@@ -42,9 +42,9 @@ services:
     env_file:
       - .locust.env
     depends_on:
-      locust_redis:
+      locust-redis:
         condition: service_started
-      locust_migrate:
+      locust-migrate:
         condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "python", "-c", "import sys, httpx; httpx.get('http://localhost:8000/health', timeout=4).raise_for_status()"]
@@ -53,13 +53,13 @@ services:
       retries: 5
       start_period: 2s
 
-  locust_redis:
+  locust-redis:
     image: redis:8
-    container_name: locust_redis
+    container_name: locust-redis
 
-  locust_db:
+  locust-db:
     image: postgres:15
-    container_name: locust_postgres_db
+    container_name: locust-postgres-db
     volumes:
       - locust_postgres_data:/var/lib/postgresql/data/
     env_file:

--- a/aqueduct/locustfiles/locust_router_config.yaml
+++ b/aqueduct/locustfiles/locust_router_config.yaml
@@ -3,7 +3,7 @@ model_list:
   litellm_params:
     model: openai/gpt-4.1-nano
     api_key: "fake_api_key"
-    api_base: "http://mock_api:45999"
+    api_base: "http://mock-api:45999"
   model_info:
     id: gpt-4.1-nano
     aliases: ["main", "coding"]
@@ -11,7 +11,7 @@ model_list:
   litellm_params:
     model: openai/text-embedding-ada-002
     api_key: "fake_api_key"
-    api_base: "http://mock_api:45999"
+    api_base: "http://mock-api:45999"
   model_info:
     id: text-embedding-ada-002
     mode: embedding
@@ -20,7 +20,7 @@ model_list:
   litellm_params:
     model: openai/gpt-4o-mini-tts
     api_key: "fake_api_key"
-    api_base: "http://mock_api:45999"
+    api_base: "http://mock-api:45999"
   model_info:
     id: gpt-4o-mini-tts
     mode: audio_speech
@@ -29,7 +29,7 @@ model_list:
   litellm_params:
     model: openai/whisper-1
     api_key: "fake_api_key"
-    api_base: "http://mock_api:45999"
+    api_base: "http://mock-api:45999"
   model_info:
     id: whisper-1
     mode: audio_transcriptions
@@ -38,7 +38,7 @@ model_list:
   litellm_params:
     model: openai/dall-e-2
     api_key: "fake_api_key"
-    api_base: "http://mock_api:45999"
+    api_base: "http://mock-api:45999"
   model_info:
     id: dall-e-2
     mode: image_generations

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
 
   migrate:
     build: .
-    container_name: django_migrate
+    container_name: django-migrate
     command: python manage.py migrate
     env_file:
       - .example.env
@@ -19,7 +19,7 @@ services:
 
   web:
     build: .
-    container_name: django_app
+    container_name: django-app
     command: |
       sh -c "python manage.py collectstatic --no-input && daphne -b 0.0.0.0 -p 8000 aqueduct.asgi:application"
     volumes:
@@ -72,7 +72,7 @@ services:
 
   db:
     image: postgres:15
-    container_name: postgres_db
+    container_name: postgres-db
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     env_file:
@@ -85,7 +85,7 @@ services:
 
   mcp-everything:
     image: node:20-slim
-    container_name: mcp_everything
+    container_name: mcp-everything
     command: npx @modelcontextprotocol/server-everything streamableHttp
     environment:
       - PORT=3001


### PR DESCRIPTION
Hyphen seems to be the preferred separator, and underscore caused DNS issues sometimes (technically, it's not allowed in DNS hostnames).