### PR TITLE
Show scaled request limit in 429 errors

### DIFF
--- a/aqueduct/gateway/tests/test_endpoints.py
+++ b/aqueduct/gateway/tests/test_endpoints.py
@@ -1553,6 +1553,9 @@ class TokenLimitTest(ChatCompletionsBase):
             429,
             f"Expected 429 Too Many Requests, got {response7.status_code}: {response7.content}",
         )
+        self.assertEqual(
+            response7.json()["error"]["message"], "Rate limit exceeded. Request limit (6/min)."
+        )
 
     @patch(
         "gateway.views.decorators.get_all_model_request_limit_multipliers",
@@ -1584,6 +1587,9 @@ class TokenLimitTest(ChatCompletionsBase):
         # Third request: weighted = 4.0 >= 3
         response3 = self._send_chat_completion(self.MESSAGES, max_completion_tokens=5)
         self.assertEqual(response3.status_code, 429)
+        self.assertEqual(
+            response3.json()["error"]["message"], "Rate limit exceeded. Request limit (1.5/min)."
+        )
 
 
 @override_settings(LITELLM_ROUTER_CONFIG_FILE_PATH="router.yaml")

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -958,7 +958,7 @@ async def _validate_mcp_tool(
     server_url = tool.get("server_url")
     if not server_url:
         if not settings.RESPONSES_API_ALLOW_EXTERNAL_MCP_SERVERS:
-            log.exception("MCP server not found - %s", server_name)
+            log.error("MCP server not found - %s", server_name)
             return error_response(f"MCP server not found - {server_name}", status=404)
         return None
 
@@ -974,7 +974,7 @@ async def _validate_mcp_tool(
 
     if not server_config:
         if not settings.RESPONSES_API_ALLOW_EXTERNAL_MCP_SERVERS:
-            log.exception("MCP server not found - %s", server_name)
+            log.error("MCP server not found - %s", server_name)
             return error_response(f"MCP server not found - {server_name}", status=404)
         return None
 

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -350,7 +350,12 @@ def check_limits(view_func: AsyncView) -> AsyncView:
                     limits.requests_per_minute is not None
                     and weighted_request_count >= limits.requests_per_minute
                 ):
-                    exceeded.append(f"Request limit ({limits.requests_per_minute}/min)")
+                    request_limit = float(limits.requests_per_minute)
+                    pydantic_model: dict[str, Any] | None = kwargs.get("pydantic_model")
+                    model = pydantic_model.get("model") if pydantic_model else None
+                    if model:
+                        request_limit *= multipliers.get(resolve_model_alias(model), 1.0)
+                    exceeded.append(f"Request limit ({request_limit:g}/min)")
 
                 if (
                     limits.input_tokens_per_minute is not None

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -140,7 +140,7 @@ def oai_client_from_body(model: str, request: ASGIRequest) -> tuple[openai.Async
     deployment: litellm.Deployment | None = router.get_deployment(model_id=model)
 
     if deployment is None:
-        log.exception("Model '%s' not found in router deployments", model)
+        log.error("Model '%s' not found in router deployments", model)
         raise openai.NotFoundError(
             message=f"Model '{model}' not found!",
             response=httpx.Response(

--- a/docs/api/batches.md
+++ b/docs/api/batches.md
@@ -101,16 +101,11 @@ curl -X POST https://your-aqueduct-domain.com/batches/{batch_id}/cancel \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Create batch
 batch = client.batches.create(
-    input_file_id="file-id",
-    completion_window="24h",
-    endpoint="/v1/chat/completions",
+    input_file_id="file-id", completion_window="24h", endpoint="/v1/chat/completions"
 )
 print(batch.id, batch.status)
 

--- a/docs/api/chat-completions.md
+++ b/docs/api/chat-completions.md
@@ -82,17 +82,14 @@ curl https://your-aqueduct-domain.com/chat/completions \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.chat.completions.create(
     model="your-model-name",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Write me a short poem!"}
-    ]
+        {"role": "user", "content": "Write me a short poem!"},
+    ],
 )
 print(response.choices[0].message.content)
 ```
@@ -122,10 +119,7 @@ curl https://your-aqueduct-domain.com/chat/completions \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    api_key="YOUR_AQUEDUCT_TOKEN",
-    base_url="https://your-aqueduct-domain.com/v1",
-)
+client = OpenAI(api_key="YOUR_AQUEDUCT_TOKEN", base_url="https://your-aqueduct-domain.com/v1")
 
 image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
 
@@ -222,10 +216,7 @@ curl "https://your-aqueduct-domain.com/chat/completions" \
 import base64
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 with open("sample.pdf", "rb") as f:
     data = f.read()
@@ -243,14 +234,11 @@ completion = client.chat.completions.create(
                     "file": {
                         "filename": "sample.pdf",
                         "file_data": f"data:application/pdf;base64,{base64_string}",
-                    }
+                    },
                 },
-                {
-                    "type": "text",
-                    "text": "What is the main topic of this document?",
-                }
+                {"type": "text", "text": "What is the main topic of this document?"},
             ],
-        },
+        }
     ],
 )
 

--- a/docs/api/completions.md
+++ b/docs/api/completions.md
@@ -60,16 +60,10 @@ curl https://your-aqueduct-domain.com/completions \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.completions.create(
-    model="your-model-name",
-    prompt="Once upon a time",
-    max_tokens=50,
-    temperature=0.7,
+    model="your-model-name", prompt="Once upon a time", max_tokens=50, temperature=0.7
 )
 print(response.choices[0].text)
 ```

--- a/docs/api/embeddings.md
+++ b/docs/api/embeddings.md
@@ -48,14 +48,10 @@ curl https://your-aqueduct-domain.com/embeddings \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.embeddings.create(
-    model="your-embedding-model-name",
-    input="The quick brown fox jumps over the lazy dog.",
+    model="your-embedding-model-name", input="The quick brown fox jumps over the lazy dog."
 )
 print(response.data[0].embedding)
 ```

--- a/docs/api/files.md
+++ b/docs/api/files.md
@@ -112,10 +112,7 @@ curl https://your-aqueduct-domain.com/files/{file_id} \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Upload file
 with open("data.jsonl", "rb") as f:

--- a/docs/api/image_generation.md
+++ b/docs/api/image_generation.md
@@ -62,16 +62,10 @@ curl https://your-aqueduct-domain.com/images/generations \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN"
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.images.generate(
-    model="dall-e-3",
-    prompt="A cute baby sea otter",
-    n=1,
-    size="1024x1024"
+    model="dall-e-3", prompt="A cute baby sea otter", n=1, size="1024x1024"
 )
 
 print(response.data[0].url)

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -77,11 +77,7 @@ async def main():
 
     async with (
         httpx.AsyncClient(headers=headers) as client,
-        streamable_http_client(url, http_client=client) as (
-            read_stream,
-            write_stream,
-            _,
-        ),
+        streamable_http_client(url, http_client=client) as (read_stream, write_stream, _),
     ):
         # Create a session
         async with ClientSession(read_stream, write_stream) as session:
@@ -95,7 +91,6 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-
 ```
 
 For more information about the Model Context Protocol,

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -30,14 +30,10 @@ curl https://your-aqueduct-domain.com/models \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 models = client.models.list()
 print(models.data)
-
 ```
 
 ## Sample Response

--- a/docs/api/responses.md
+++ b/docs/api/responses.md
@@ -97,15 +97,12 @@ curl https://your-aqueduct-domain.com/v1/responses \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.responses.create(
     model="your-model-name",
     input=[{"role": "user", "content": "Hello, how are you?"}],
-    max_output_tokens=50
+    max_output_tokens=50,
 )
 
 print(response.output)
@@ -116,10 +113,7 @@ print(response.output)
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 tools = [
     {
@@ -127,24 +121,24 @@ tools = [
         "name": "get_current_weather",
         "description": "Get the current weather in a given location",
         "parameters": {
-          "type": "object",
-          "properties": {
-              "location": {
-                  "type": "string",
-                  "description": "The city and state, e.g. San Francisco, CA",
-              },
-              "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-          },
-          "required": ["location", "unit"],
-        }
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA",
+                },
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location", "unit"],
+        },
     }
 ]
 
 response = client.responses.create(
-  model="your-model-name",
-  tools=tools,
-  input="What is the weather like in Boston today?",
-  tool_choice="auto"
+    model="your-model-name",
+    tools=tools,
+    input="What is the weather like in Boston today?",
+    tool_choice="auto",
 )
 
 print(response)
@@ -155,10 +149,7 @@ print(response)
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Use an MCP tool from a configured server
 response = client.responses.create(
@@ -169,9 +160,9 @@ response = client.responses.create(
             "type": "mcp",
             "name": "search_web",
             "server_label": "search",  # Must be configured and accessible to token
-            "description": "Search the web for information"
+            "description": "Search the web for information",
         }
-    ]
+    ],
 )
 ```
 

--- a/docs/api/speech.md
+++ b/docs/api/speech.md
@@ -56,10 +56,7 @@ curl https://your-aqueduct-domain.com/audio/speech \
 from pathlib import Path
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN"
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 speech_file_path = Path("/tmp") / "speech.mp3"
 

--- a/docs/api/transcriptions.md
+++ b/docs/api/transcriptions.md
@@ -55,18 +55,12 @@ curl https://your-aqueduct-domain.com/audio/transcriptions \
 from pathlib import Path
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN"
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 audio_file = Path("/path/to/audio.mp3")
 
 transcription = client.audio.transcriptions.create(
-    model="whisper-1",
-    file=audio_file,
-    language="en",
-    response_format="verbose_json"
+    model="whisper-1", file=audio_file, language="en", response_format="verbose_json"
 )
 
 print(transcription.text)

--- a/docs/api/vector-stores.md
+++ b/docs/api/vector-stores.md
@@ -332,10 +332,7 @@ curl https://your-aqueduct-domain.com/vector_stores/{vector_store_id}/file_batch
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Create a vector store
 vector_store = client.vector_stores.create(name="Support FAQ")
@@ -343,8 +340,7 @@ print(f"Created vector store: {vector_store.id}")
 
 # Create with files attached
 vector_store_with_files = client.vector_stores.create(
-    name="Documentation",
-    file_ids=["file_abc123", "file_def456"]
+    name="Documentation", file_ids=["file_abc123", "file_def456"]
 )
 print(f"Created vector store with files: {vector_store_with_files.id}")
 
@@ -363,49 +359,34 @@ vs = client.vector_stores.update(
     vector_store.id,
     name="Updated Product Documentation",
     description="Comprehensive product documentation",
-    metadata={"category": "support"}
+    metadata={"category": "support"},
 )
 print(f"Updated name: {vs.name}")
 
 # Search a vector store
 results = client.vector_stores.search(
-    vector_store.id,
-    query="How do I reset my password?",
-    max_num_results=10,
-    rewrite_query=True
+    vector_store.id, query="How do I reset my password?", max_num_results=10, rewrite_query=True
 )
 print(f"Search query: {results.search_query}")
 for result in results.data:
     print(f"  File: {result.filename} (score: {result.score})")
 
 # Add a file to a vector store
-vs_file = client.vector_stores.files.create(
-    vector_store.id,
-    file_id="file_abc123"
-)
+vs_file = client.vector_stores.files.create(vector_store.id, file_id="file_abc123")
 print(f"Added file with status: {vs_file.status}")
 
 # List files in a vector store
-files = client.vector_stores.files.list(
-    vector_store.id,
-    limit=20,
-    filter="completed"
-)
+files = client.vector_stores.files.list(vector_store.id, limit=20, filter="completed")
 for file in files.data:
     print(f"{file.id}: status={file.status}")
 
 # Retrieve a file in a vector store
-vs_file = client.vector_stores.files.retrieve(
-    vector_store.id,
-    vs_file.id
-)
+vs_file = client.vector_stores.files.retrieve(vector_store.id, vs_file.id)
 print(f"File status: {vs_file.status}, usage_bytes: {vs_file.usage_bytes}")
 
 # Update file attributes
 vs_file = client.vector_stores.files.update(
-    vector_store.id,
-    vs_file.id,
-    attributes={"category": "finance", "priority": "high"}
+    vector_store.id, vs_file.id, attributes={"category": "finance", "priority": "high"}
 )
 print(f"Updated file attributes: {vs_file.attributes}")
 
@@ -413,52 +394,34 @@ print(f"Updated file attributes: {vs_file.attributes}")
 batch = client.vector_stores.file_batches.create(
     vector_store.id,
     files=[
-        {
-            "file_id": "file_abc123",
-            "attributes": {"category": "getting-started"}
-        },
+        {"file_id": "file_abc123", "attributes": {"category": "getting-started"}},
         {
             "file_id": "file_def456",
             "chunking_strategy": {
                 "type": "static",
-                "static": {
-                    "max_chunk_size_tokens": 1200,
-                    "chunk_overlap_tokens": 200
-                }
-            }
-        }
-    ]
+                "static": {"max_chunk_size_tokens": 1200, "chunk_overlap_tokens": 200},
+            },
+        },
+    ],
 )
 print(f"Batch status: {batch.status}")
 print(f"File counts: {batch.file_counts}")
 
 # Retrieve batch status
-batch = client.vector_stores.file_batches.retrieve(
-    vector_store.id,
-    batch.id
-)
+batch = client.vector_stores.file_batches.retrieve(vector_store.id, batch.id)
 print(f"Batch file_counts: {batch.file_counts}")
 
 # Cancel a batch
-batch = client.vector_stores.file_batches.cancel(
-    vector_store.id,
-    batch.id
-)
+batch = client.vector_stores.file_batches.cancel(vector_store.id, batch.id)
 print(f"Batch cancelled: {batch.status}")
 
 # List files in a batch
-batch_files = client.vector_stores.file_batches.list_files(
-    vector_store.id,
-    batch.id
-)
+batch_files = client.vector_stores.file_batches.list_files(vector_store.id, batch.id)
 for file in batch_files.data:
     print(f"Batch file: {file.id}")
 
 # Delete a file from vector store
-client.vector_stores.files.delete(
-    vector_store.id,
-    vs_file.id
-)
+client.vector_stores.files.delete(vector_store.id, vs_file.id)
 print("File deleted from vector store")
 
 # Delete a vector store


### PR DESCRIPTION
Closes #167

## Summary

- apply the current model request-limit multiplier to the limit shown in 429 responses
- resolve model aliases before reading the multiplier
- preserve compact output for both whole and fractional scaled limits
- add regression assertions for 2x and 0.5x model multipliers

## Root cause

Rate-limit enforcement already used a weighted request count, but the error message always interpolated the unscaled base `requests_per_minute` value. This made the reported quota disagree with the quota users experienced for models with a multiplier.

## Validation

- `uv run python manage.py test gateway.tests.test_endpoints.TokenLimitTest` (11 passed)
- focused multiplier tests (2 passed)
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy`
- `uv run pre-commit run --all-files`

The full `gateway` suite ran 194 tests locally; three unrelated MCP live-server classes failed during macOS multiprocessing startup with `AppRegistryNotReady` / `Server stopped`. The focused suite and all static checks pass, and upstream Linux CI covers the full gateway lane.

## Coordination

Draft PR #163 refactors rate-limit storage and currently retains the same base-limit message behavior. This patch targets current `main`; if #163 lands first, the message calculation will need a mechanical rebase into its new rate-limiting module.

## AI assistance disclosure

This contribution was implemented, tested, and documented with OpenAI Codex assistance under the submitter's direction.