### PR TITLE
Linting issues; missing `@tos_accepted` decorator; update GH pipeline actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,22 +20,22 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       # Uses the `docker/login-action` action to log in to the Container registry
       # using the account and password that will publish the packages. Once published,
       # the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action)
       # to extract tags and labels that will be applied to the specified image.
@@ -43,7 +43,7 @@ jobs:
       # The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on
@@ -55,7 +55,7 @@ jobs:
       # from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           platforms: linux/amd64,linux/arm64
           provenance: false
@@ -71,7 +71,7 @@ jobs:
       # who consume the image. For more information, see
       # [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations).
       - name: Generate artifact attestation
-        uses: actions/attest@v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d  # v4.2.1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
       # using the account and password that will publish the packages. Once published,
       # the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+      artifact-metadata: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -68,7 +69,7 @@ jobs:
       # This step generates an artifact attestation for the image, which is an unforgeable
       # statement about where and how it was built. It increases supply chain security for people
       # who consume the image. For more information, see
-      # [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      # [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations).
       - name: Generate artifact attestation
         uses: actions/attest@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,8 +19,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+        uses: actions/checkout@v7
+      # Uses the `docker/login-action` action to log in to the Container registry
+      # using the account and password that will publish the packages. Once published,
+      # the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
@@ -29,23 +31,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action)
+      # to extract tags and labels that will be applied to the specified image.
+      # The `id` "meta" allows the output of this step to be referenced in a subsequent step.
+      # The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      # This step uses the `docker/build-push-action` action to build the image, based on
+      # your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located
+      # in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage)
+      # in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output
+      # from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6.17.0
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           provenance: false
@@ -56,11 +65,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha
 
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      # This step generates an artifact attestation for the image, which is an unforgeable
+      # statement about where and how it was built. It increases supply chain security for people
+      # who consume the image. For more information, see
+      # [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,22 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: ".python-version"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24.x'
 
       - name: Set up ruff and run `ruff check`
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.1.0
 
       - name: Ruff - check imports
         run: ruff check --select I
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Run docker compose
-        uses: hoverkraft-tech/compose-action@v2.2.0
+        uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4  # v3.0.0
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,16 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version-file: ".python-version"
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '24.x'
 
       - name: Set up ruff and run `ruff check`
-        uses: astral-sh/ruff-action@v4.1.0
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
 
       - name: Ruff - check imports
         run: ruff check --select I
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Run docker compose
         uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4  # v3.0.0
         env:

--- a/aqueduct/gateway/views/batches.py
+++ b/aqueduct/gateway/views/batches.py
@@ -134,6 +134,7 @@ async def batches(
 @csrf_exempt
 @require_http_methods(["GET"])
 @token_authenticated(token_auth_only=True)
+@tos_accepted
 @log_request
 @catch_router_exceptions
 async def batch(
@@ -192,6 +193,7 @@ async def batch(
 @csrf_exempt
 @require_POST
 @token_authenticated(token_auth_only=False)
+@tos_accepted
 @log_request
 @catch_router_exceptions
 async def batch_cancel(

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -539,13 +539,12 @@ async def file_to_bytes(token: Token | None, file: FileFile) -> bytes:
                 client = get_files_api_client()
             except ValueError as e:
                 raise ValueError(f"Files API not configured: {e}") from e
-            response = await client.files.content(file_obj.id)
-            return response.content
         except FileObject.DoesNotExist:
             raise
         except Exception as e:
             raise ValueError(f"Failed to read file with id {file_id}: {e}") from e
         else:
+            response = await client.files.content(file_obj.id)
             return response.content
     else:
         raise RuntimeError("Neither 'file_data' nor 'file_id' are given.")
@@ -953,7 +952,7 @@ async def _validate_mcp_tool(
     server_url = tool.get("server_url")
     if not server_url:
         if not settings.RESPONSES_API_ALLOW_EXTERNAL_MCP_SERVERS:
-            log.exception("MCP server not found - %s", server_name)
+            log.error("MCP server not found - %s", server_name)
             return error_response(f"MCP server not found - {server_name}", status=404)
         return None
 
@@ -969,7 +968,7 @@ async def _validate_mcp_tool(
 
     if not server_config:
         if not settings.RESPONSES_API_ALLOW_EXTERNAL_MCP_SERVERS:
-            log.exception("MCP server not found - %s", server_name)
+            log.error("MCP server not found - %s", server_name)
             return error_response(f"MCP server not found - {server_name}", status=404)
         return None
 

--- a/aqueduct/gateway/views/files.py
+++ b/aqueduct/gateway/views/files.py
@@ -251,6 +251,7 @@ async def files(
 @csrf_exempt
 @require_http_methods(["GET", "DELETE"])
 @token_authenticated(token_auth_only=True)
+@tos_accepted
 @log_request
 @catch_router_exceptions
 async def file(
@@ -301,6 +302,7 @@ async def file(
 @csrf_exempt
 @require_GET
 @token_authenticated(token_auth_only=True)
+@tos_accepted
 @log_request
 @catch_router_exceptions
 async def file_content(

--- a/aqueduct/gateway/views/image_generation.py
+++ b/aqueduct/gateway/views/image_generation.py
@@ -19,6 +19,7 @@ from .decorators import (
     parse_body,
     resolve_alias,
     token_authenticated,
+    tos_accepted,
 )
 from .utils import _get_token_usage, oai_client_from_body
 
@@ -28,6 +29,7 @@ log = logging.getLogger("aqueduct")
 @csrf_exempt
 @require_POST
 @token_authenticated(token_auth_only=True)
+@tos_accepted
 @parse_body(model=TypeAdapter(ImageGenerateParams, config=ConfigDict(extra="forbid")))
 @check_limits
 @resolve_alias

--- a/aqueduct/gateway/views/responses.py
+++ b/aqueduct/gateway/views/responses.py
@@ -38,9 +38,9 @@ from .utils import (
 @csrf_exempt
 @require_POST
 @token_authenticated(token_auth_only=True)
+@tos_accepted
 @parse_body(model=TypeAdapter(openai.types.responses.ResponseCreateParams))
 @check_limits
-@tos_accepted
 @resolve_alias
 @check_model_availability
 @check_tool_availability

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -140,7 +140,7 @@ def oai_client_from_body(model: str, request: ASGIRequest) -> tuple[openai.Async
     deployment: litellm.Deployment | None = router.get_deployment(model_id=model)
 
     if deployment is None:
-        log.exception("Model '%s' not found in router deployments", model)
+        log.error("Model '%s' not found in router deployments", model)
         raise openai.NotFoundError(
             message=f"Model '{model}' not found!",
             response=httpx.Response(
@@ -148,7 +148,7 @@ def oai_client_from_body(model: str, request: ASGIRequest) -> tuple[openai.Async
                 status_code=404,
             ),
             body=None,
-        ) from None
+        )
 
     model_relay, _provider, _, _ = litellm.get_llm_provider(deployment.litellm_params.model)
     return client, model_relay

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -426,5 +426,7 @@ LOGGING = {
 
 if TESTING:
     logger = logging.getLogger("aqueduct")
-    logging.disable(logging.NOTSET)
-    logger.setLevel(logging.DEBUG)
+    logging.disable(logging.ERROR)
+    logger.setLevel(logging.CRITICAL)
+    # logging.disable(logging.NOTSET)
+    # logger.setLevel(logging.DEBUG)

--- a/docs/api/batches.md
+++ b/docs/api/batches.md
@@ -101,16 +101,11 @@ curl -X POST https://your-aqueduct-domain.com/batches/{batch_id}/cancel \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Create batch
 batch = client.batches.create(
-    input_file_id="file-id",
-    completion_window="24h",
-    endpoint="/v1/chat/completions",
+    input_file_id="file-id", completion_window="24h", endpoint="/v1/chat/completions"
 )
 print(batch.id, batch.status)
 

--- a/docs/api/chat-completions.md
+++ b/docs/api/chat-completions.md
@@ -82,17 +82,14 @@ curl https://your-aqueduct-domain.com/chat/completions \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.chat.completions.create(
     model="your-model-name",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Write me a short poem!"}
-    ]
+        {"role": "user", "content": "Write me a short poem!"},
+    ],
 )
 print(response.choices[0].message.content)
 ```
@@ -122,10 +119,7 @@ curl https://your-aqueduct-domain.com/chat/completions \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    api_key="YOUR_AQUEDUCT_TOKEN",
-    base_url="https://your-aqueduct-domain.com/v1",
-)
+client = OpenAI(api_key="YOUR_AQUEDUCT_TOKEN", base_url="https://your-aqueduct-domain.com/v1")
 
 image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
 
@@ -222,10 +216,7 @@ curl "https://your-aqueduct-domain.com/chat/completions" \
 import base64
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 with open("sample.pdf", "rb") as f:
     data = f.read()
@@ -243,14 +234,11 @@ completion = client.chat.completions.create(
                     "file": {
                         "filename": "sample.pdf",
                         "file_data": f"data:application/pdf;base64,{base64_string}",
-                    }
+                    },
                 },
-                {
-                    "type": "text",
-                    "text": "What is the main topic of this document?",
-                }
+                {"type": "text", "text": "What is the main topic of this document?"},
             ],
-        },
+        }
     ],
 )
 

--- a/docs/api/completions.md
+++ b/docs/api/completions.md
@@ -60,16 +60,10 @@ curl https://your-aqueduct-domain.com/completions \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.completions.create(
-    model="your-model-name",
-    prompt="Once upon a time",
-    max_tokens=50,
-    temperature=0.7,
+    model="your-model-name", prompt="Once upon a time", max_tokens=50, temperature=0.7
 )
 print(response.choices[0].text)
 ```

--- a/docs/api/embeddings.md
+++ b/docs/api/embeddings.md
@@ -48,14 +48,10 @@ curl https://your-aqueduct-domain.com/embeddings \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.embeddings.create(
-    model="your-embedding-model-name",
-    input="The quick brown fox jumps over the lazy dog.",
+    model="your-embedding-model-name", input="The quick brown fox jumps over the lazy dog."
 )
 print(response.data[0].embedding)
 ```

--- a/docs/api/files.md
+++ b/docs/api/files.md
@@ -112,10 +112,7 @@ curl https://your-aqueduct-domain.com/files/{file_id} \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Upload file
 with open("data.jsonl", "rb") as f:

--- a/docs/api/image_generation.md
+++ b/docs/api/image_generation.md
@@ -62,16 +62,10 @@ curl https://your-aqueduct-domain.com/images/generations \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN"
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.images.generate(
-    model="dall-e-3",
-    prompt="A cute baby sea otter",
-    n=1,
-    size="1024x1024"
+    model="dall-e-3", prompt="A cute baby sea otter", n=1, size="1024x1024"
 )
 
 print(response.data[0].url)

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -77,11 +77,7 @@ async def main():
 
     async with (
         httpx.AsyncClient(headers=headers) as client,
-        streamable_http_client(url, http_client=client) as (
-            read_stream,
-            write_stream,
-            _,
-        ),
+        streamable_http_client(url, http_client=client) as (read_stream, write_stream, _),
     ):
         # Create a session
         async with ClientSession(read_stream, write_stream) as session:
@@ -95,7 +91,6 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-
 ```
 
 For more information about the Model Context Protocol,

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -30,14 +30,10 @@ curl https://your-aqueduct-domain.com/models \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 models = client.models.list()
 print(models.data)
-
 ```
 
 ## Sample Response

--- a/docs/api/responses.md
+++ b/docs/api/responses.md
@@ -97,15 +97,12 @@ curl https://your-aqueduct-domain.com/v1/responses \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 response = client.responses.create(
     model="your-model-name",
     input=[{"role": "user", "content": "Hello, how are you?"}],
-    max_output_tokens=50
+    max_output_tokens=50,
 )
 
 print(response.output)
@@ -116,10 +113,7 @@ print(response.output)
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 tools = [
     {
@@ -127,24 +121,24 @@ tools = [
         "name": "get_current_weather",
         "description": "Get the current weather in a given location",
         "parameters": {
-          "type": "object",
-          "properties": {
-              "location": {
-                  "type": "string",
-                  "description": "The city and state, e.g. San Francisco, CA",
-              },
-              "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-          },
-          "required": ["location", "unit"],
-        }
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA",
+                },
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location", "unit"],
+        },
     }
 ]
 
 response = client.responses.create(
-  model="your-model-name",
-  tools=tools,
-  input="What is the weather like in Boston today?",
-  tool_choice="auto"
+    model="your-model-name",
+    tools=tools,
+    input="What is the weather like in Boston today?",
+    tool_choice="auto",
 )
 
 print(response)
@@ -155,10 +149,7 @@ print(response)
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Use an MCP tool from a configured server
 response = client.responses.create(
@@ -169,9 +160,9 @@ response = client.responses.create(
             "type": "mcp",
             "name": "search_web",
             "server_label": "search",  # Must be configured and accessible to token
-            "description": "Search the web for information"
+            "description": "Search the web for information",
         }
-    ]
+    ],
 )
 ```
 

--- a/docs/api/speech.md
+++ b/docs/api/speech.md
@@ -56,10 +56,7 @@ curl https://your-aqueduct-domain.com/audio/speech \
 from pathlib import Path
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN"
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 speech_file_path = Path("/tmp") / "speech.mp3"
 

--- a/docs/api/transcriptions.md
+++ b/docs/api/transcriptions.md
@@ -55,18 +55,12 @@ curl https://your-aqueduct-domain.com/audio/transcriptions \
 from pathlib import Path
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com/v1",
-    api_key="YOUR_AQUEDUCT_TOKEN"
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com/v1", api_key="YOUR_AQUEDUCT_TOKEN")
 
 audio_file = Path("/path/to/audio.mp3")
 
 transcription = client.audio.transcriptions.create(
-    model="whisper-1",
-    file=audio_file,
-    language="en",
-    response_format="verbose_json"
+    model="whisper-1", file=audio_file, language="en", response_format="verbose_json"
 )
 
 print(transcription.text)

--- a/docs/api/vector-stores.md
+++ b/docs/api/vector-stores.md
@@ -332,10 +332,7 @@ curl https://your-aqueduct-domain.com/vector_stores/{vector_store_id}/file_batch
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="https://your-aqueduct-domain.com",
-    api_key="YOUR_AQUEDUCT_TOKEN",
-)
+client = OpenAI(base_url="https://your-aqueduct-domain.com", api_key="YOUR_AQUEDUCT_TOKEN")
 
 # Create a vector store
 vector_store = client.vector_stores.create(name="Support FAQ")
@@ -343,8 +340,7 @@ print(f"Created vector store: {vector_store.id}")
 
 # Create with files attached
 vector_store_with_files = client.vector_stores.create(
-    name="Documentation",
-    file_ids=["file_abc123", "file_def456"]
+    name="Documentation", file_ids=["file_abc123", "file_def456"]
 )
 print(f"Created vector store with files: {vector_store_with_files.id}")
 
@@ -363,49 +359,34 @@ vs = client.vector_stores.update(
     vector_store.id,
     name="Updated Product Documentation",
     description="Comprehensive product documentation",
-    metadata={"category": "support"}
+    metadata={"category": "support"},
 )
 print(f"Updated name: {vs.name}")
 
 # Search a vector store
 results = client.vector_stores.search(
-    vector_store.id,
-    query="How do I reset my password?",
-    max_num_results=10,
-    rewrite_query=True
+    vector_store.id, query="How do I reset my password?", max_num_results=10, rewrite_query=True
 )
 print(f"Search query: {results.search_query}")
 for result in results.data:
     print(f"  File: {result.filename} (score: {result.score})")
 
 # Add a file to a vector store
-vs_file = client.vector_stores.files.create(
-    vector_store.id,
-    file_id="file_abc123"
-)
+vs_file = client.vector_stores.files.create(vector_store.id, file_id="file_abc123")
 print(f"Added file with status: {vs_file.status}")
 
 # List files in a vector store
-files = client.vector_stores.files.list(
-    vector_store.id,
-    limit=20,
-    filter="completed"
-)
+files = client.vector_stores.files.list(vector_store.id, limit=20, filter="completed")
 for file in files.data:
     print(f"{file.id}: status={file.status}")
 
 # Retrieve a file in a vector store
-vs_file = client.vector_stores.files.retrieve(
-    vector_store.id,
-    vs_file.id
-)
+vs_file = client.vector_stores.files.retrieve(vector_store.id, vs_file.id)
 print(f"File status: {vs_file.status}, usage_bytes: {vs_file.usage_bytes}")
 
 # Update file attributes
 vs_file = client.vector_stores.files.update(
-    vector_store.id,
-    vs_file.id,
-    attributes={"category": "finance", "priority": "high"}
+    vector_store.id, vs_file.id, attributes={"category": "finance", "priority": "high"}
 )
 print(f"Updated file attributes: {vs_file.attributes}")
 
@@ -413,52 +394,34 @@ print(f"Updated file attributes: {vs_file.attributes}")
 batch = client.vector_stores.file_batches.create(
     vector_store.id,
     files=[
-        {
-            "file_id": "file_abc123",
-            "attributes": {"category": "getting-started"}
-        },
+        {"file_id": "file_abc123", "attributes": {"category": "getting-started"}},
         {
             "file_id": "file_def456",
             "chunking_strategy": {
                 "type": "static",
-                "static": {
-                    "max_chunk_size_tokens": 1200,
-                    "chunk_overlap_tokens": 200
-                }
-            }
-        }
-    ]
+                "static": {"max_chunk_size_tokens": 1200, "chunk_overlap_tokens": 200},
+            },
+        },
+    ],
 )
 print(f"Batch status: {batch.status}")
 print(f"File counts: {batch.file_counts}")
 
 # Retrieve batch status
-batch = client.vector_stores.file_batches.retrieve(
-    vector_store.id,
-    batch.id
-)
+batch = client.vector_stores.file_batches.retrieve(vector_store.id, batch.id)
 print(f"Batch file_counts: {batch.file_counts}")
 
 # Cancel a batch
-batch = client.vector_stores.file_batches.cancel(
-    vector_store.id,
-    batch.id
-)
+batch = client.vector_stores.file_batches.cancel(vector_store.id, batch.id)
 print(f"Batch cancelled: {batch.status}")
 
 # List files in a batch
-batch_files = client.vector_stores.file_batches.list_files(
-    vector_store.id,
-    batch.id
-)
+batch_files = client.vector_stores.file_batches.list_files(vector_store.id, batch.id)
 for file in batch_files.data:
     print(f"Batch file: {file.id}")
 
 # Delete a file from vector store
-client.vector_stores.files.delete(
-    vector_store.id,
-    vs_file.id
-)
+client.vector_stores.files.delete(vector_store.id, vs_file.id)
 print("File deleted from vector store")
 
 # Delete a vector store

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ wheels = [
 
 [[package]]
 name = "aqueduct"
-version = "0.1.16"
+version = "0.1.18"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION
- In some of the views, `@tos_accepted` decorator was missing. It seems to me that it must have been an oversight; or do you know if there was a reason why it wasn't added?
- I've fixed deprecation warnings from the GH actions: multiple actions depended on an old version of Node, so I just updated them all to the newest version.
- The attestation action complained about a permission to write artifact metadata it needed; the docs also stated that this permission should be enabled, so I added it to the list. 
- A few days ago a new version of ruff was released (0.16); it now by default formats code snippets in Markdown files - so these are just formatting changes. It also (rightly) complained about logging `log.exception()` where no exception had been raised.