### PR TITLE
Pin django-tos to >=1.1.0,<1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "django-celery-beat>=2.8.1",
     "django-cors-headers>=4.7.0",
     "django-silk>=5.5.0",
-    "django-tos>=1.1.0",
+    "django-tos>=1.1.0, <1.2",  # 1.2 rewrote the middleware (new-style __call__)
     "httpx>=0.28.1, <1",
     "litellm==1.85.2",
     "mcp==1.25.0",

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ requires-dist = [
     { name = "django-celery-beat", specifier = ">=2.8.1" },
     { name = "django-cors-headers", specifier = ">=4.7.0" },
     { name = "django-silk", specifier = ">=5.5.0" },
-    { name = "django-tos", specifier = ">=1.1.0" },
+    { name = "django-tos", specifier = ">=1.1.0,<1.2" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "litellm", specifier = "==1.85.2" },
     { name = "mcp", specifier = "==1.25.0" },


### PR DESCRIPTION
django-tos 1.2 rewrote the middleware to a new-style __call__ (no process_request), which breaks our UserAgreementMiddleware subclass. Keep resolution on the tested 1.1.x line.