### PR TITLE
145: Pass raw claims dict to get_org_name_from_groups (Part 1/3)

### DIFF
--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -126,7 +126,7 @@ def my_org_name_extractor(groups: list[str]) -> str | None:
 
 
 OIDC_DEFAULT_GROUPS = ["default"]
-ORG_NAME_FROM_OIDC_GROUPS_FUNCTION = lambda x: "default"
+ORG_NAME_FROM_OIDC_FUNCTION = lambda x: "default"
 ADMIN_GROUP = "default"  # all users are admins
 
 # OAuth Group Management Settings

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -22,21 +22,21 @@ def default_org_name_from_groups(groups: list[str]) -> str | None:
     return groups[0]
 
 
-def get_org_name_from_groups(groups) -> str | None:
+def get_org_name_from_groups(claims) -> str | None:
     """
     Extracts the organization name from the user's groups.
     """
     if hasattr(settings, "ORG_NAME_FROM_OIDC_GROUPS_FUNCTION"):
-        return settings.ORG_NAME_FROM_OIDC_GROUPS_FUNCTION(groups)
-    return default_org_name_from_groups(groups)
+        return settings.ORG_NAME_FROM_OIDC_GROUPS_FUNCTION(claims)
+    return default_org_name_from_groups(claims)
 
 
 class OIDCBackend(OIDCAuthenticationBackend):
     def _groups(self, claims) -> list[str]:
         return claims.get("groups", settings.OIDC_DEFAULT_GROUPS)
 
-    def _org(self, groups: list[str]) -> Org | None:
-        org_name = get_org_name_from_groups(groups)
+    def _org(self, claims) -> Org | None:
+        org_name = get_org_name_from_groups(claims)
         if not org_name:
             return None  # Authentication fails if no org can be determined
         org, _created = Org.objects.get_or_create(name=org_name)
@@ -200,7 +200,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
     def create_user(self, claims) -> User | None:
         groups = self._groups(claims)
-        org = self._org(groups)
+        org = self._org(claims)
         if not org:
             return None  # Authentication fails if no org can be determined
 
@@ -232,7 +232,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
     def update_user(self, user, claims) -> User:
         """Update existing user with new claims, if necessary save, and return user"""
         groups = self._groups(claims)
-        org = self._org(groups)
+        org = self._org(claims)
 
         try:
             profile = UserProfile.objects.get(user=user)

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -12,23 +12,23 @@ User = get_user_model()
 log = logging.getLogger("aqueduct")
 
 
-def default_org_name_from_groups(groups: list[str]) -> str | None:
+def default_org_name(claims) -> str | None:
     """
-    Default implementation to extract organization name, which returns the first group in the list.
-    Override this or set ORG_NAME_FROM_OIDC_FUNCTION in settings.
+    Default implementation to extract organization name from claims.
+    Returns the first group in the claims['groups'] list.
     """
-    if not groups:
-        return None
-    return groups[0]
+    if groups := claims.get("groups"):
+        return groups[0]
+    return None
 
 
 def get_org_name(claims) -> str | None:
     """
-    Extracts the organization name from the user's groups.
+    Extracts the organization name from the OIDC claims payload.
     """
     if hasattr(settings, "ORG_NAME_FROM_OIDC_FUNCTION"):
         return settings.ORG_NAME_FROM_OIDC_FUNCTION(claims)
-    return default_org_name_from_groups(claims)
+    return default_org_name(claims)
 
 
 class OIDCBackend(OIDCAuthenticationBackend):
@@ -36,8 +36,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
         return claims.get("groups", settings.OIDC_DEFAULT_GROUPS)
 
     def _org(self, claims) -> Org | None:
-        org_name = get_org_name(claims)
-        if not org_name:
+        if not (org_name := get_org_name(claims)):
             return None  # Authentication fails if no org can be determined
         org, _created = Org.objects.get_or_create(name=org_name)
         return org

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Literal
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -12,14 +13,11 @@ User = get_user_model()
 log = logging.getLogger("aqueduct")
 
 
-def default_org_name(claims) -> str | None:
+def default_org_name() -> Literal["default"]:
     """
-    Default implementation to extract organization name from claims.
-    Returns the first group in the claims['groups'] list.
+    Returns the default organization name.
     """
-    if groups := claims.get("groups"):
-        return groups[0]
-    return None
+    return "default"
 
 
 def get_org_name(claims) -> str | None:
@@ -28,7 +26,7 @@ def get_org_name(claims) -> str | None:
     """
     if hasattr(settings, "ORG_NAME_FROM_OIDC_FUNCTION"):
         return settings.ORG_NAME_FROM_OIDC_FUNCTION(claims)
-    return default_org_name(claims)
+    return default_org_name()
 
 
 class OIDCBackend(OIDCAuthenticationBackend):

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -15,19 +15,19 @@ log = logging.getLogger("aqueduct")
 def default_org_name_from_groups(groups: list[str]) -> str | None:
     """
     Default implementation to extract organization name, which returns the first group in the list.
-    Override this or set ORG_NAME_FROM_OIDC_GROUPS_FUNCTION in settings.
+    Override this or set ORG_NAME_FROM_OIDC_FUNCTION in settings.
     """
     if not groups:
         return None
     return groups[0]
 
 
-def get_org_name_from_groups(claims) -> str | None:
+def get_org_name(claims) -> str | None:
     """
     Extracts the organization name from the user's groups.
     """
-    if hasattr(settings, "ORG_NAME_FROM_OIDC_GROUPS_FUNCTION"):
-        return settings.ORG_NAME_FROM_OIDC_GROUPS_FUNCTION(claims)
+    if hasattr(settings, "ORG_NAME_FROM_OIDC_FUNCTION"):
+        return settings.ORG_NAME_FROM_OIDC_FUNCTION(claims)
     return default_org_name_from_groups(claims)
 
 
@@ -36,7 +36,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
         return claims.get("groups", settings.OIDC_DEFAULT_GROUPS)
 
     def _org(self, claims) -> Org | None:
-        org_name = get_org_name_from_groups(claims)
+        org_name = get_org_name(claims)
         if not org_name:
             return None  # Authentication fails if no org can be determined
         org, _created = Org.objects.get_or_create(name=org_name)

--- a/aqueduct/management/tests/test_oidc_org_extraction.py
+++ b/aqueduct/management/tests/test_oidc_org_extraction.py
@@ -4,32 +4,20 @@ from management.auth import OIDCBackend, default_org_name, get_org_name
 from management.models import Org
 
 
+def _extract_org_from_first_group(claims: dict) -> str | None:
+    """Test helper to extract org name from the first group in claims."""
+    if groups := claims.get("groups"):
+        return groups[0]
+    return None
+
+
 class DefaultOrgNameTestCase(TestCase):
-    """Test the default_org_name function."""
+    """Test the default_org_name function returns a constant literal value."""
 
-    def test_returns_first_group(self):
-        """Test that default_org_name returns the first group."""
-        claims = {"groups": ["org-alpha", "org-beta", "org-gamma"]}
-        result = default_org_name(claims)
-        self.assertEqual(result, "org-alpha")
-
-    def test_returns_none_when_no_groups(self):
-        """Test that default_org_name returns None when groups key is missing."""
-        claims = {"email": "test@example.com", "name": "Test User"}
-        result = default_org_name(claims)
-        self.assertIsNone(result)
-
-    def test_returns_none_when_groups_is_empty_list(self):
-        """Test that default_org_name returns None when groups is empty."""
-        claims = {"groups": []}
-        result = default_org_name(claims)
-        self.assertIsNone(result)
-
-    def test_returns_none_when_groups_is_none(self):
-        """Test that default_org_name returns None when groups is None."""
-        claims = {"groups": None}
-        result = default_org_name(claims)
-        self.assertIsNone(result)
+    def test_returns_default_literal(self):
+        """Test that default_org_name returns the constant string 'default'."""
+        result = default_org_name()
+        self.assertEqual(result, "default")
 
 
 class GetOrgNameTestCase(TestCase):
@@ -66,7 +54,7 @@ class GetOrgNameTestCase(TestCase):
 @override_settings(
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
-    ORG_NAME_FROM_OIDC_FUNCTION=default_org_name,
+    ORG_NAME_FROM_OIDC_FUNCTION=_extract_org_from_first_group,
 )
 class OIDCBackendOrgTestCase(TestCase):
     """Test the OIDCBackend._org() method."""
@@ -122,7 +110,7 @@ class OIDCBackendOrgTestCase(TestCase):
 @override_settings(
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
-    ORG_NAME_FROM_OIDC_FUNCTION=default_org_name,
+    ORG_NAME_FROM_OIDC_FUNCTION=_extract_org_from_first_group,
 )
 class OIDCBackendOrgIntegrationTestCase(TestCase):
     """Integration tests for org creation in authentication flow."""

--- a/aqueduct/management/tests/test_oidc_org_extraction.py
+++ b/aqueduct/management/tests/test_oidc_org_extraction.py
@@ -1,0 +1,157 @@
+from django.test import TestCase, override_settings
+
+from management.auth import OIDCBackend, default_org_name, get_org_name
+from management.models import Org
+
+
+class DefaultOrgNameTestCase(TestCase):
+    """Test the default_org_name function."""
+
+    def test_returns_first_group(self):
+        """Test that default_org_name returns the first group."""
+        claims = {"groups": ["org-alpha", "org-beta", "org-gamma"]}
+        result = default_org_name(claims)
+        self.assertEqual(result, "org-alpha")
+
+    def test_returns_none_when_no_groups(self):
+        """Test that default_org_name returns None when groups key is missing."""
+        claims = {"email": "test@example.com", "name": "Test User"}
+        result = default_org_name(claims)
+        self.assertIsNone(result)
+
+    def test_returns_none_when_groups_is_empty_list(self):
+        """Test that default_org_name returns None when groups is empty."""
+        claims = {"groups": []}
+        result = default_org_name(claims)
+        self.assertIsNone(result)
+
+    def test_returns_none_when_groups_is_none(self):
+        """Test that default_org_name returns None when groups is None."""
+        claims = {"groups": None}
+        result = default_org_name(claims)
+        self.assertIsNone(result)
+
+
+class GetOrgNameTestCase(TestCase):
+    """Test the get_org_name function with custom configurations."""
+
+    def test_uses_default_implementation_when_setting_is_none(self):
+        """Test that get_org_name uses default_org_name when setting returns None."""
+        claims = {"groups": ["test-org"]}
+        result = get_org_name(claims)
+        self.assertEqual(result, "default")
+
+    @override_settings(ORG_NAME_FROM_OIDC_FUNCTION=lambda claims: claims.get("custom_org"))
+    def test_uses_custom_function_when_configured(self):
+        """Test that get_org_name uses custom function when ORG_NAME_FROM_OIDC_FUNCTION is set."""
+        claims = {"groups": ["default-org"], "custom_org": "custom-org"}
+        result = get_org_name(claims)
+        self.assertEqual(result, "custom-org")
+
+    @override_settings(ORG_NAME_FROM_OIDC_FUNCTION=lambda claims: claims.get("groups", [""])[-1])
+    def test_custom_function_can_extract_last_group(self):
+        """Test custom function that extracts the last group instead of first."""
+        claims = {"groups": ["org-first", "org-middle", "org-last"]}
+        result = get_org_name(claims)
+        self.assertEqual(result, "org-last")
+
+    @override_settings(ORG_NAME_FROM_OIDC_FUNCTION=lambda claims: None)
+    def test_custom_function_can_return_none(self):
+        """Test that custom function can return None to indicate no org."""
+        claims = {"groups": ["some-org"]}
+        result = get_org_name(claims)
+        self.assertIsNone(result)
+
+
+@override_settings(
+    OIDC_RP_SIGN_ALGO="HS256",
+    OIDC_RP_IDP_SIGN_KEY="test-key",
+    ORG_NAME_FROM_OIDC_FUNCTION=default_org_name,
+)
+class OIDCBackendOrgTestCase(TestCase):
+    """Test the OIDCBackend._org() method."""
+
+    def setUp(self):
+        self.backend = OIDCBackend()
+
+    def test_creates_org_if_not_exists(self):
+        """Test that _org creates a new Org if it doesn't exist."""
+        claims = {"groups": ["new-org"]}
+        self.assertEqual(Org.objects.count(), 0)
+        org = self.backend._org(claims)
+        self.assertEqual(Org.objects.count(), 1)
+        self.assertEqual(org.name, "new-org")
+        self.assertIsInstance(org, Org)
+
+    def test_reuses_existing_org(self):
+        """Test that _org reuses an existing Org."""
+        Org.objects.create(name="existing-org")
+        self.assertEqual(Org.objects.count(), 1)
+
+        claims = {"groups": ["existing-org"]}
+        org = self.backend._org(claims)
+
+        self.assertEqual(Org.objects.count(), 1)
+        self.assertEqual(org.name, "existing-org")
+
+    def test_returns_none_when_no_org_name(self):
+        """Test that _org returns None when no org name can be extracted."""
+        claims = {"email": "test@example.com"}
+        org = self.backend._org(claims)
+        self.assertIsNone(org)
+
+    def test_returns_none_when_groups_empty(self):
+        """Test that _org returns None when groups list is empty."""
+        claims = {"groups": []}
+        org = self.backend._org(claims)
+        self.assertIsNone(org)
+
+    def test_returns_none_when_groups_none(self):
+        """Test that _org returns None when groups is None."""
+        claims = {"groups": None}
+        org = self.backend._org(claims)
+        self.assertIsNone(org)
+
+    def test_first_group_determines_org(self):
+        """Test that the first group determines the organization."""
+        claims = {"groups": ["primary-org", "secondary-org", "tertiary-org"]}
+        org = self.backend._org(claims)
+        self.assertEqual(org.name, "primary-org")
+
+
+@override_settings(
+    OIDC_RP_SIGN_ALGO="HS256",
+    OIDC_RP_IDP_SIGN_KEY="test-key",
+    ORG_NAME_FROM_OIDC_FUNCTION=default_org_name,
+)
+class OIDCBackendOrgIntegrationTestCase(TestCase):
+    """Integration tests for org creation in authentication flow."""
+
+    def setUp(self):
+        self.backend = OIDCBackend()
+
+    def test_multiple_users_same_org_reuse_org(self):
+        """Test that multiple users from same org reuse the same Org object."""
+        claims1 = {"groups": ["shared-org"], "email": "user1@example.com"}
+        claims2 = {"groups": ["shared-org"], "email": "user2@example.com"}
+
+        org1 = self.backend._org(claims1)
+        org2 = self.backend._org(claims2)
+
+        self.assertEqual(Org.objects.count(), 1)
+        self.assertEqual(org1.id, org2.id)
+        self.assertEqual(org1.name, "shared-org")
+        self.assertEqual(org2.name, "shared-org")
+
+    def test_multiple_users_different_orgs_create_separate_orgs(self):
+        """Test that users from different orgs create separate Org objects."""
+        claims1 = {"groups": ["org-a"], "email": "user1@example.com"}
+        claims2 = {"groups": ["org-b"], "email": "user2@example.com"}
+
+        org1 = self.backend._org(claims1)
+        org2 = self.backend._org(claims2)
+
+        self.assertEqual(Org.objects.count(), 2)
+        self.assertNotEqual(org1.id, org2.id)
+        self.assertEqual(org1.name, "org-a")
+        self.assertEqual(org2.name, "org-b")

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -126,7 +126,7 @@ def my_org_name_extractor(groups: list[str]) -> str | None:
 
 
 OIDC_DEFAULT_GROUPS = ["default"]
-ORG_NAME_FROM_OIDC_GROUPS_FUNCTION = lambda x: "default"
+ORG_NAME_FROM_OIDC_FUNCTION = lambda x: "default"
 ADMIN_GROUP = "default"  # all users are admins
 
 # OAuth Group Management Settings

--- a/charts/aqueduct/values.yaml
+++ b/charts/aqueduct/values.yaml
@@ -113,7 +113,7 @@ settingsPy:
   extra: |
     # You can add/override settings here
     # OIDC_DEFAULT_GROUPS = ["default"]
-    # ORG_NAME_FROM_OIDC_GROUPS_FUNCTION = lambda x: "default"
+    # ORG_NAME_FROM_OIDC_FUNCTION = lambda x: "default"
     # ADMIN_GROUP = "default"
 
 # Router configuration for litellm router


### PR DESCRIPTION
1. Changed the `groups` parameter to `claims` in organization mapping resolution logic.
2. Renamed `get_org_name_from_groups` to `get_org_name` to reflect the updated claims signature.
3. Updated docstrings and comments.
4. Updated existing unit tests and added test cases.