### PR TITLE
145: Pass raw claims dict to _get_teams_from_groups (Part 2/2)

### DIFF
--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -137,7 +137,7 @@ ENABLE_OAUTH_GROUP_CREATION = os.getenv("ENABLE_OAUTH_GROUP_CREATION", "True").l
 ENABLE_OAUTH_GROUP_REMOVAL = os.getenv("ENABLE_OAUTH_GROUP_REMOVAL", "True").lower() == "true"
 
 
-def default_oauth_team_names_from_groups(
+def default_oauth_team_names(
     group: str, groups: list[str] | None = None
 ) -> tuple[str, str] | None:
     """
@@ -160,7 +160,7 @@ def default_oauth_team_names_from_groups(
     return None
 
 
-OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION = default_oauth_team_names_from_groups
+OAUTH_TEAM_NAMES_FUNCTION = default_oauth_team_names
 
 EXTRA_NAV_LINKS = {
     "Bug Report": "https://github.com/TU-Wien-dataLAB/aqueduct/issues/new?template=bug_report.md",

--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -138,30 +138,47 @@ ENABLE_OAUTH_GROUP_CREATION = os.getenv("ENABLE_OAUTH_GROUP_CREATION", "True").l
 ENABLE_OAUTH_GROUP_REMOVAL = os.getenv("ENABLE_OAUTH_GROUP_REMOVAL", "True").lower() == "true"
 
 
-def default_oauth_team_names(claims) -> list[tuple[str, str]]:
+def default_oauth_team_names(claims) -> list[str]:
     """
-    Default function to transform OAuth claims to team mappings.
+    Default function to extract team names from OAuth claims.
 
     Args:
-        claims: The full OAuth claims dict containing 'groups' and other user info
+        claims: The full OAuth claims dict.
 
     Returns:
-        List of (team_name, original_group_name) tuples, or empty list if none.
+        List of team names, or empty list if none.
 
     Example:
-        def my_transform(claims) -> list[tuple[str, str]]:
-            groups = claims.get('groups', [])
+        def my_extract_team_names(claims) -> list[str]:
+            team_names = claims.get('groups', [])
+            return [team_name for team_name in team_names if team_name.startswith('E')]
+    """
+    return []
+
+
+def default_oauth_display_team_names(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Default function to map team names to display team names.
+
+    Args:
+        team_names: List of team names.
+
+    Returns:
+        List of (display_team_name, team_name) tuples, or empty list if none.
+
+    Example:
+        def my_display_team_names(team_names) -> list[tuple[str, str]]:
             result = []
-            for group in groups:
-                if group.startswith('E'):
-                    team_name = group.split('-')[0]
-                    result.append((team_name, group))
+            for team_name in team_names:
+                display_team_name = team_name.split('-')[0]
+                result.append((display_team_name, team_name))
             return result
     """
     return []
 
 
 OAUTH_TEAM_NAMES_FUNCTION = default_oauth_team_names
+OAUTH_DISPLAY_TEAM_NAMES_FUNCTION = default_oauth_display_team_names
 
 EXTRA_NAV_LINKS = {
     "Bug Report": "https://github.com/TU-Wien-dataLAB/aqueduct/issues/new?template=bug_report.md",

--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import logging
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -132,32 +131,35 @@ ADMIN_GROUP = "default"  # all users are admins
 # OAuth Group Management Settings
 # Controls automatic team creation and membership management from OAuth groups
 
-ENABLE_OAUTH_GROUP_MANAGEMENT = os.getenv("ENABLE_OAUTH_GROUP_MANAGEMENT", "False").lower() == "true"
+ENABLE_OAUTH_GROUP_MANAGEMENT = (
+    os.getenv("ENABLE_OAUTH_GROUP_MANAGEMENT", "False").lower() == "true"
+)
 ENABLE_OAUTH_GROUP_CREATION = os.getenv("ENABLE_OAUTH_GROUP_CREATION", "True").lower() == "true"
 ENABLE_OAUTH_GROUP_REMOVAL = os.getenv("ENABLE_OAUTH_GROUP_REMOVAL", "True").lower() == "true"
 
 
-def default_oauth_team_names(
-    group: str, groups: list[str] | None = None
-) -> tuple[str, str] | None:
+def default_oauth_team_names(claims) -> list[tuple[str, str]]:
     """
-    Default function to transform a single OAuth group name to a team name.
+    Default function to transform OAuth claims to team mappings.
 
     Args:
-        group: The specific OAuth group name to transform
-        groups: Full list of user's groups for context (optional)
+        claims: The full OAuth claims dict containing 'groups' and other user info
 
     Returns:
-        Tuple of (transformed_team_name, original_group_name) or None to skip this group
+        List of tuples: [(transformed_team_name, original_group_name), ...]
+        or empty list to skip team creation
 
     Example:
-        def my_transform(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-            if group.startswith("E"):
-                team_name = group.split("-")[0]
-                return (team_name, group)
-            return None
+        def my_transform(claims) -> list[tuple[str, str]]:
+            groups = claims.get('groups', [])
+            result = []
+            for group in groups:
+                if group.startswith('E'):
+                    team_name = group.split('-')[0]
+                    result.append((team_name, group))
+            return result
     """
-    return None
+    return []
 
 
 OAUTH_TEAM_NAMES_FUNCTION = default_oauth_team_names

--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -138,7 +138,7 @@ ENABLE_OAUTH_GROUP_CREATION = os.getenv("ENABLE_OAUTH_GROUP_CREATION", "True").l
 ENABLE_OAUTH_GROUP_REMOVAL = os.getenv("ENABLE_OAUTH_GROUP_REMOVAL", "True").lower() == "true"
 
 
-def default_oauth_team_names(claims) -> list[str]:
+def default_oauth_team_names(claims: dict[str, Any]) -> list[str]:
     """
     Default function to extract team names from OAuth claims.
 

--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -174,7 +174,7 @@ def default_oauth_display_team_names(team_names: list[str]) -> list[tuple[str, s
                 result.append((display_team_name, team_name))
             return result
     """
-    return []
+    return [(t, t) for t in team_names]
 
 
 OAUTH_TEAM_NAMES_FUNCTION = default_oauth_team_names

--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -146,8 +146,7 @@ def default_oauth_team_names(claims) -> list[tuple[str, str]]:
         claims: The full OAuth claims dict containing 'groups' and other user info
 
     Returns:
-        List of tuples: [(transformed_team_name, original_group_name), ...]
-        or empty list to skip team creation
+        List of (team_name, original_group_name) tuples, or empty list if none.
 
     Example:
         def my_transform(claims) -> list[tuple[str, str]]:

--- a/aqueduct/management/admin.py
+++ b/aqueduct/management/admin.py
@@ -198,48 +198,67 @@ def sync_oauth_team_names_action(modeladmin, request, queryset):
         modeladmin.message_user(request, "No OAuth-managed teams selected", level=messages.INFO)
         return
 
-    teams_to_update = []
-    teams_to_delete = []
-    teams_skipped = []
-
     all_oauth_groups = list(
         Team.objects.exclude(oauth_group_name="")
         .values_list("oauth_group_name", flat=True)
         .distinct()
     )
+    claims = {"groups": all_oauth_groups}
+
+    try:
+        result = func(claims)
+    except Exception as e:
+        log.exception("Error calling OAUTH_TEAM_NAMES_FUNCTION: %s", e)
+        modeladmin.message_user(
+            request, f"Error calling OAUTH_TEAM_NAMES_FUNCTION: {e}", level=messages.ERROR
+        )
+        return
+
+    if result is None:
+        modeladmin.message_user(
+            request, "OAUTH_TEAM_NAMES_FUNCTION returned None", level=messages.WARNING
+        )
+        return
+
+    if not isinstance(result, list):
+        log.error("OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples")
+        modeladmin.message_user(
+            request, "OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples", level=messages.ERROR
+        )
+        return
+
+    # Build mapping from original_group_name -> new_team_name
+    new_mapping = {}
+    for item in result:
+        if isinstance(item, tuple) and len(item) == 2:  # noqa: PLR2004
+            team_name, original_group_name = item
+            new_mapping[original_group_name.strip()] = team_name.strip()
+
+    teams_to_update = []
+    teams_to_delete = []
+    teams_skipped = []
 
     max_skipped_display = 5
 
     for team in oauth_teams:
         original_group = team.oauth_group_name
-        try:
-            result = func(original_group, all_oauth_groups)
-            if result is None:
-                teams_to_delete.append(team)
-            elif isinstance(result, tuple) and len(result) == 2:  # noqa: PLR2004 (tuple length for (name, original_group))
-                new_team_name, _ = result
-                new_team_name = new_team_name.strip()
-                if new_team_name == team.name:
-                    teams_skipped.append((team, "Name unchanged"))
-                else:
-                    existing = Team.objects.filter(name=new_team_name, org=team.org).exclude(
-                        pk=team.pk
-                    )
-                    if existing.exists():
-                        teams_skipped.append(
-                            (team, f"Name collision: '{new_team_name}' already exists")
-                        )
-                    else:
-                        teams_to_update.append((team, new_team_name))
-            else:
-                log.error(
-                    "OAUTH_TEAM_NAMES_FUNCTION must return tuple[str, str] | None for group '%s'",
-                    original_group,
-                )
-                teams_skipped.append((team, "Invalid return type"))
-        except Exception as e:
-            log.exception("Error processing team '%s': %s", team.name, e)
-            teams_skipped.append((team, f"Error: {e}"))
+
+        if original_group not in new_mapping:
+            teams_to_delete.append(team)
+            continue
+
+        new_team_name = new_mapping[original_group]
+        if new_team_name == team.name:
+            teams_skipped.append((team, "Name unchanged"))
+            continue
+
+        collision_teams = Team.objects.filter(name=new_team_name, org=team.org).exclude(pk=team.pk)
+
+        if collision_teams.exists():
+            teams_skipped.append((team, f"Name collision: '{new_team_name}' already exists"))
+            continue
+
+        teams_to_update.append((team, new_team_name))
 
     if teams_to_delete:
         modeladmin.message_user(

--- a/aqueduct/management/admin.py
+++ b/aqueduct/management/admin.py
@@ -203,9 +203,6 @@ def _get_new_mapping() -> dict[str, str]:
     except Exception as e:
         raise ImproperlyConfigured(f"Error calling OAUTH_DISPLAY_TEAM_NAMES_FUNCTION: {e}") from e
 
-    if result is None:
-        raise ImproperlyConfigured("OAUTH_DISPLAY_TEAM_NAMES_FUNCTION returned None")
-
     if not isinstance(result, list):
         raise ImproperlyConfigured("OAUTH_DISPLAY_TEAM_NAMES_FUNCTION must return a list of tuples")
 

--- a/aqueduct/management/admin.py
+++ b/aqueduct/management/admin.py
@@ -263,45 +263,45 @@ def sync_oauth_team_names_action(modeladmin, request, queryset: QuerySet[Team]):
 
     try:
         new_mapping = _get_new_mapping()
-    except (OAuthConfigurationError, OAuthFunctionError) as e:
+    except (OAuthConfigurationError, OAuthFunctionError, Exception) as e:
         modeladmin.message_user(request, str(e), level=messages.ERROR)
         return
 
     result = _classify_teams_for_sync(oauth_teams, new_mapping)
 
+    message, level = None, None
+
     if result.teams_to_delete:
-        modeladmin.message_user(
-            request,
+        message = (
             f"Warning: {len(result.teams_to_delete)} team(s) would be deleted. "
-            "Deletion is not performed automatically. "
-            "Please delete these teams manually if needed.",
-            level=messages.WARNING,
+            f"Deletion is not performed automatically. "
+            f"Please delete these teams manually if needed."
         )
+        level = messages.WARNING
 
     if result.teams_to_update:
         for team, new_name in result.teams_to_update:
             team.name = new_name
+
         Team.objects.bulk_update([t for t, _ in result.teams_to_update], ["name"])
 
-    if result.teams_to_update:
-        modeladmin.message_user(
-            request,
-            f"Successfully updated {len(result.teams_to_update)} team(s)",
-            level=messages.SUCCESS,
-        )
+        message = f"Successfully updated {len(result.teams_to_update)} team(s)"
+        level = messages.SUCCESS
 
     if result.teams_skipped:
         max_display = 5
         skip_details = "; ".join(
             f"{team.name}: {reason}" for team, reason in result.teams_skipped[:max_display]
         )
+
         if len(result.teams_skipped) > max_display:
             skip_details += f" and {len(result.teams_skipped) - max_display} more"
-        modeladmin.message_user(
-            request,
-            f"Skipped {len(result.teams_skipped)} team(s): {skip_details}",
-            level=messages.WARNING,
-        )
+
+        message = f"Skipped {len(result.teams_skipped)} team(s): {skip_details}"
+        level = messages.WARNING
+
+    if message and level:
+        modeladmin.message_user(request, message, level=level)
 
 
 @admin.action(description="Reload from upstream")

--- a/aqueduct/management/admin.py
+++ b/aqueduct/management/admin.py
@@ -184,10 +184,10 @@ def sync_oauth_team_names_action(modeladmin, request, queryset):
     Admin action to sync team names from OAuth group mappings.
     Only affects OAuth-managed teams (those with oauth_group_name set).
     """
-    func = getattr(settings, "OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION", None)
+    func = getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", None)
     if not func:
         modeladmin.message_user(
-            request, "OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION not configured", level=messages.WARNING
+            request, "OAUTH_TEAM_NAMES_FUNCTION not configured", level=messages.WARNING
         )
         return
 
@@ -233,7 +233,7 @@ def sync_oauth_team_names_action(modeladmin, request, queryset):
                         teams_to_update.append((team, new_team_name))
             else:
                 log.error(
-                    "OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION must return "
+                    "OAUTH_TEAM_NAMES_FUNCTION must return "
                     "tuple[str, str] | None for group '%s'",
                     original_group,
                 )
@@ -472,7 +472,7 @@ class TeamAdmin(admin.ModelAdmin):
                     {
                         "fields": ("name", "description", "org"),
                         "description": "This team is managed by OAuth synchronization. "
-                        "To update the team name, modify the OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION "
+                        "To update the team name, modify the OAUTH_TEAM_NAMES_FUNCTION "
                         "setting and use the 'Sync OAuth team names' action above.",
                     },
                 ),

--- a/aqueduct/management/admin.py
+++ b/aqueduct/management/admin.py
@@ -233,8 +233,7 @@ def sync_oauth_team_names_action(modeladmin, request, queryset):
                         teams_to_update.append((team, new_team_name))
             else:
                 log.error(
-                    "OAUTH_TEAM_NAMES_FUNCTION must return "
-                    "tuple[str, str] | None for group '%s'",
+                    "OAUTH_TEAM_NAMES_FUNCTION must return tuple[str, str] | None for group '%s'",
                     original_group,
                 )
                 teams_skipped.append((team, "Invalid return type"))

--- a/aqueduct/management/admin.py
+++ b/aqueduct/management/admin.py
@@ -10,12 +10,12 @@ from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import Group, User
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q, QuerySet
 from django.urls import reverse
 from django.utils.html import format_html
 
 from gateway.config import get_files_api_client, get_router_config
-from management.exceptions import OAuthConfigurationError, OAuthFunctionError
 from management.models import (
     Batch,
     FileObject,
@@ -189,32 +189,31 @@ def delete_tos_cache(modeladmin, request, queryset):
 
 
 def _get_new_mapping() -> dict[str, str]:
-    if not (func := getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", None)):
-        raise OAuthConfigurationError("OAUTH_TEAM_NAMES_FUNCTION not configured")
-
     all_oauth_groups = list(
         Team.objects.exclude(oauth_group_name="")
         .values_list("oauth_group_name", flat=True)
         .distinct()
     )
-    claims = {"groups": all_oauth_groups}
+
+    if not (func := getattr(settings, "OAUTH_DISPLAY_TEAM_NAMES_FUNCTION", None)):
+        raise ImproperlyConfigured("OAUTH_DISPLAY_TEAM_NAMES_FUNCTION not configured")
 
     try:
-        result = func(claims)
+        result = func(all_oauth_groups)
     except Exception as e:
-        raise OAuthFunctionError(f"Error calling OAUTH_TEAM_NAMES_FUNCTION: {e}") from e
+        raise ImproperlyConfigured(f"Error calling OAUTH_DISPLAY_TEAM_NAMES_FUNCTION: {e}") from e
 
     if result is None:
-        raise OAuthConfigurationError("OAUTH_TEAM_NAMES_FUNCTION returned None")
+        raise ImproperlyConfigured("OAUTH_DISPLAY_TEAM_NAMES_FUNCTION returned None")
 
     if not isinstance(result, list):
-        raise OAuthConfigurationError("OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples")
+        raise ImproperlyConfigured("OAUTH_DISPLAY_TEAM_NAMES_FUNCTION must return a list of tuples")
 
     new_mapping = {}
     for item in result:
         if isinstance(item, tuple) and len(item) == 2:  # noqa: PLR2004
-            team_name, original_group_name = item
-            new_mapping[original_group_name.strip()] = team_name.strip()
+            display_team_name, team_name = item
+            new_mapping[team_name.strip()] = display_team_name.strip()
 
     return new_mapping
 
@@ -263,7 +262,7 @@ def sync_oauth_team_names_action(modeladmin, request, queryset: QuerySet[Team]):
 
     try:
         new_mapping = _get_new_mapping()
-    except (OAuthConfigurationError, OAuthFunctionError, Exception) as e:
+    except Exception as e:
         modeladmin.message_user(request, str(e), level=messages.ERROR)
         return
 

--- a/aqueduct/management/admin.py
+++ b/aqueduct/management/admin.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import ClassVar
 
@@ -14,8 +15,8 @@ from django.urls import reverse
 from django.utils.html import format_html
 
 from gateway.config import get_files_api_client, get_router_config
-
-from .models import (
+from management.exceptions import OAuthConfigurationError, OAuthFunctionError
+from management.models import (
     Batch,
     FileObject,
     Org,
@@ -31,6 +32,15 @@ from .models import (
 )
 
 log = logging.getLogger("aqueduct")
+
+
+@dataclass
+class TeamSyncResult:
+    """Result of classifying teams for OAuth sync."""
+
+    teams_to_update: list[tuple[Team, str]]
+    teams_to_delete: list[Team]
+    teams_skipped: list[tuple[Team, str]]
 
 
 def format_unix_timestamp(timestamp: int | None) -> str:
@@ -178,25 +188,9 @@ def delete_tos_cache(modeladmin, request, queryset):
         cache.delete(f"django:tos:agreed:{user.id}", version=key_version)
 
 
-@admin.action(description="Sync OAuth team names")
-def sync_oauth_team_names_action(modeladmin, request, queryset):
-    """
-    Admin action to sync team names from OAuth group mappings.
-    Only affects OAuth-managed teams (those with oauth_group_name set).
-    """
-    func = getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", None)
-    if not func:
-        modeladmin.message_user(
-            request, "OAUTH_TEAM_NAMES_FUNCTION not configured", level=messages.WARNING
-        )
-        return
-
-    # Only process OAuth-managed teams
-    oauth_teams = queryset.exclude(oauth_group_name="")
-
-    if not oauth_teams.exists():
-        modeladmin.message_user(request, "No OAuth-managed teams selected", level=messages.INFO)
-        return
+def _get_new_mapping() -> dict[str, str]:
+    if not (func := getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", None)):
+        raise OAuthConfigurationError("OAUTH_TEAM_NAMES_FUNCTION not configured")
 
     all_oauth_groups = list(
         Team.objects.exclude(oauth_group_name="")
@@ -208,90 +202,105 @@ def sync_oauth_team_names_action(modeladmin, request, queryset):
     try:
         result = func(claims)
     except Exception as e:
-        log.exception("Error calling OAUTH_TEAM_NAMES_FUNCTION: %s", e)
-        modeladmin.message_user(
-            request, f"Error calling OAUTH_TEAM_NAMES_FUNCTION: {e}", level=messages.ERROR
-        )
-        return
+        raise OAuthFunctionError(f"Error calling OAUTH_TEAM_NAMES_FUNCTION: {e}") from e
 
     if result is None:
-        modeladmin.message_user(
-            request, "OAUTH_TEAM_NAMES_FUNCTION returned None", level=messages.WARNING
-        )
-        return
+        raise OAuthConfigurationError("OAUTH_TEAM_NAMES_FUNCTION returned None")
 
     if not isinstance(result, list):
-        log.error("OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples")
-        modeladmin.message_user(
-            request, "OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples", level=messages.ERROR
-        )
-        return
+        raise OAuthConfigurationError("OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples")
 
-    # Build mapping from original_group_name -> new_team_name
     new_mapping = {}
     for item in result:
         if isinstance(item, tuple) and len(item) == 2:  # noqa: PLR2004
             team_name, original_group_name = item
             new_mapping[original_group_name.strip()] = team_name.strip()
 
-    teams_to_update = []
-    teams_to_delete = []
-    teams_skipped = []
+    return new_mapping
 
-    max_skipped_display = 5
+
+def _classify_teams_for_sync(
+    oauth_teams: QuerySet[Team], new_mapping: dict[str, str]
+) -> TeamSyncResult:
+    """Classify teams into update/delete/skip categories."""
+    teams_to_update: list[tuple[Team, str]] = []
+    teams_to_delete: list[Team] = []
+    teams_skipped: list[tuple[Team, str]] = []
 
     for team in oauth_teams:
         original_group = team.oauth_group_name
 
-        if original_group not in new_mapping:
+        if not (new_team_name := new_mapping.get(original_group)):
             teams_to_delete.append(team)
             continue
 
-        new_team_name = new_mapping[original_group]
         if new_team_name == team.name:
             teams_skipped.append((team, "Name unchanged"))
             continue
 
-        collision_teams = Team.objects.filter(name=new_team_name, org=team.org).exclude(pk=team.pk)
-
-        if collision_teams.exists():
+        collision = Team.objects.filter(name=new_team_name, org=team.org).exclude(pk=team.pk)
+        if collision.exists():
             teams_skipped.append((team, f"Name collision: '{new_team_name}' already exists"))
             continue
 
         teams_to_update.append((team, new_team_name))
 
-    if teams_to_delete:
+    return TeamSyncResult(teams_to_update, teams_to_delete, teams_skipped)
+
+
+@admin.action(description="Sync OAuth team names")
+def sync_oauth_team_names_action(modeladmin, request, queryset: QuerySet[Team]):
+    """
+    Admin action to sync team names from OAuth group mappings.
+    Only affects OAuth-managed teams (those with oauth_group_name set).
+    """
+
+    # Only process OAuth-managed teams
+    oauth_teams = queryset.exclude(oauth_group_name="")
+    if not oauth_teams.exists():
+        modeladmin.message_user(request, "No OAuth-managed teams selected", level=messages.INFO)
+        return
+
+    try:
+        new_mapping = _get_new_mapping()
+    except (OAuthConfigurationError, OAuthFunctionError) as e:
+        modeladmin.message_user(request, str(e), level=messages.ERROR)
+        return
+
+    result = _classify_teams_for_sync(oauth_teams, new_mapping)
+
+    if result.teams_to_delete:
         modeladmin.message_user(
             request,
-            f"Warning: {len(teams_to_delete)} team(s) would be deleted. "
+            f"Warning: {len(result.teams_to_delete)} team(s) would be deleted. "
             "Deletion is not performed automatically. "
             "Please delete these teams manually if needed.",
             level=messages.WARNING,
         )
 
-    for team, new_name in teams_to_update:
-        team.name = new_name
+    if result.teams_to_update:
+        for team, new_name in result.teams_to_update:
+            team.name = new_name
+        Team.objects.bulk_update([t for t, _ in result.teams_to_update], ["name"])
 
-    if teams_to_update:
-        Team.objects.bulk_update([t for t, _ in teams_to_update], ["name"])
-
-    updated_count = len(teams_to_update)
-    skipped_count = len(teams_skipped)
-
-    # Report results
-    if updated_count > 0:
+    if result.teams_to_update:
         modeladmin.message_user(
-            request, f"Successfully updated {updated_count} team(s)", level=messages.SUCCESS
+            request,
+            f"Successfully updated {len(result.teams_to_update)} team(s)",
+            level=messages.SUCCESS,
         )
 
-    if skipped_count > 0:
+    if result.teams_skipped:
+        max_display = 5
         skip_details = "; ".join(
-            [f"{team.name}: {reason}" for team, reason in teams_skipped[:max_skipped_display]]
+            f"{team.name}: {reason}" for team, reason in result.teams_skipped[:max_display]
         )
-        if len(teams_skipped) > max_skipped_display:
-            skip_details += f" and {len(teams_skipped) - max_skipped_display} more"  # type: ignore[operator]
+        if len(result.teams_skipped) > max_display:
+            skip_details += f" and {len(result.teams_skipped) - max_display} more"
         modeladmin.message_user(
-            request, f"Skipped {skipped_count} team(s): {skip_details}", level=messages.WARNING
+            request,
+            f"Skipped {len(result.teams_skipped)} team(s): {skip_details}",
+            level=messages.WARNING,
         )
 
 

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -54,9 +54,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
         if not getattr(settings, "ENABLE_OAUTH_GROUP_MANAGEMENT", False):
             return []
 
-        func = getattr(
-            settings, "OAUTH_TEAM_NAMES_FUNCTION", lambda group, groups=None: None
-        )
+        func = getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", lambda group, groups=None: None)
 
         team_mappings = []
         groups = claims.get("groups", [])
@@ -68,9 +66,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
                 result = func(group, groups)
             except Exception as e:
                 log.exception(
-                    "Error calling OAUTH_TEAM_NAMES_FUNCTION for group '%s': %s",
-                    group,
-                    e,
+                    "Error calling OAUTH_TEAM_NAMES_FUNCTION for group '%s': %s", group, e
                 )
                 continue
 

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -42,10 +42,10 @@ class OIDCBackend(OIDCAuthenticationBackend):
         org, _created = Org.objects.get_or_create(name=org_name)
         return org
 
-    def _get_teams_from_groups(self, groups: list[str]) -> list[tuple[str, str]]:
+    def _get_teams(self, claims) -> list[tuple[str, str]]:
         """
-        Get list of (team_name, original_group_name) tuples to create/join from OAuth groups.
-        Calls OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION setting for each group.
+        Get list of (team_name, original_group_name) tuples to create/join from OAuth claims.
+        Calls OAUTH_TEAM_NAMES_FUNCTION setting for each group in claims.
         Returns empty list on error or if feature is disabled.
 
         Returns:
@@ -55,9 +55,11 @@ class OIDCBackend(OIDCAuthenticationBackend):
             return []
 
         func = getattr(
-            settings, "OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION", lambda group, groups=None: None
+            settings, "OAUTH_TEAM_NAMES_FUNCTION", lambda group, groups=None: None
         )
+
         team_mappings = []
+        groups = claims.get("groups", [])
         if not groups:
             return team_mappings
 
@@ -66,7 +68,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
                 result = func(group, groups)
             except Exception as e:
                 log.exception(
-                    "Error calling OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION for group '%s': %s",
+                    "Error calling OAUTH_TEAM_NAMES_FUNCTION for group '%s': %s",
                     group,
                     e,
                 )
@@ -74,16 +76,16 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
             if not isinstance(result, tuple) or len(result) != 2:  # noqa: PLR2004
                 continue
-            team_name, original_name = result
-            if not (team_name and isinstance(team_name, str) and original_name):
+            team_name, original_group_name = result
+            if not (team_name and isinstance(team_name, str) and original_group_name):
                 continue
-            team_mappings.append((team_name.strip(), original_name.strip()))
+            team_mappings.append((team_name.strip(), original_group_name.strip()))
 
         return team_mappings
 
-    def _sync_teams(self, user: User, profile: UserProfile, groups: list[str]) -> None:
+    def _sync_teams(self, user: User, profile: UserProfile, claims: dict) -> None:
         """
-        Synchronize team membership based on OAuth groups.
+        Synchronize team membership based on OAuth claims.
 
         - Creates teams if ENABLE_OAUTH_GROUP_CREATION=True and team doesn't exist
         - Adds user to teams via TeamMembership
@@ -95,12 +97,11 @@ class OIDCBackend(OIDCAuthenticationBackend):
         if not getattr(settings, "ENABLE_OAUTH_GROUP_MANAGEMENT", False):
             return
 
-        team_mappings = self._get_teams_from_groups(groups)
+        team_mappings = self._get_teams(claims)
         if not team_mappings:
             return
 
         org = profile.org
-
         with transaction.atomic():
             existing_memberships = set(
                 TeamMembership.objects.filter(user_profile=profile).values_list(
@@ -224,8 +225,8 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
         log.info("Created user '%s' (%s)", user.email, profile.group)
 
-        # Sync team membership from OAuth groups
-        self._sync_teams(user, profile, groups)
+        # Sync team membership from OAuth claims
+        self._sync_teams(user, profile, claims)
 
         return user
 
@@ -261,7 +262,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
         log.info("Updated user '%s' (%s)", user.email, profile.group)
 
-        # Sync team membership from OAuth groups
-        self._sync_teams(user, profile, groups)
+        # Sync team membership from OAuth claims
+        self._sync_teams(user, profile, claims)
 
         return user

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -47,7 +47,7 @@ class OIDCBackend(OIDCAuthenticationBackend):
         Get list of (team_name, original_group_name) tuples to create/join from OAuth claims.
         Calls OAUTH_TEAM_NAMES_FUNCTION setting with the full claims dict.
         The function should return a list of (team_name, original_group_name) tuples,
-        or None/empty list to skip team creation.
+        or empty list to skip team creation.
 
         Returns:
             List of tuples: [(transformed_team_name, original_oauth_group_name), ...]

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -45,8 +45,9 @@ class OIDCBackend(OIDCAuthenticationBackend):
     def _get_teams(self, claims) -> list[tuple[str, str]]:
         """
         Get list of (team_name, original_group_name) tuples to create/join from OAuth claims.
-        Calls OAUTH_TEAM_NAMES_FUNCTION setting for each group in claims.
-        Returns empty list on error or if feature is disabled.
+        Calls OAUTH_TEAM_NAMES_FUNCTION setting with the full claims dict.
+        The function should return a list of (team_name, original_group_name) tuples,
+        or None/empty list to skip team creation.
 
         Returns:
             List of tuples: [(transformed_team_name, original_oauth_group_name), ...]
@@ -54,25 +55,26 @@ class OIDCBackend(OIDCAuthenticationBackend):
         if not getattr(settings, "ENABLE_OAUTH_GROUP_MANAGEMENT", False):
             return []
 
-        func = getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", lambda group, groups=None: None)
+        func = getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", lambda claims: None)
+
+        try:
+            result = func(claims)
+        except Exception as e:
+            log.exception("Error calling OAUTH_TEAM_NAMES_FUNCTION: %s", e)
+            return []
+
+        if result is None:
+            return []
+
+        if not isinstance(result, list):
+            log.error("OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples")
+            return []
 
         team_mappings = []
-        groups = claims.get("groups", [])
-        if not groups:
-            return team_mappings
-
-        for group in groups:
-            try:
-                result = func(group, groups)
-            except Exception as e:
-                log.exception(
-                    "Error calling OAUTH_TEAM_NAMES_FUNCTION for group '%s': %s", group, e
-                )
+        for item in result:
+            if not isinstance(item, tuple) or len(item) != 2:  # noqa: PLR2004
                 continue
-
-            if not isinstance(result, tuple) or len(result) != 2:  # noqa: PLR2004
-                continue
-            team_name, original_group_name = result
+            team_name, original_group_name = item
             if not (team_name and isinstance(team_name, str) and original_group_name):
                 continue
             team_mappings.append((team_name.strip(), original_group_name.strip()))

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -30,27 +30,19 @@ def get_org_name(claims) -> str | None:
 
 
 class OIDCBackend(OIDCAuthenticationBackend):
-    def _groups(self, claims) -> list[str]:
-        return claims.get("groups", settings.OIDC_DEFAULT_GROUPS)
-
     def _org(self, claims) -> Org | None:
         if not (org_name := get_org_name(claims)):
             return None  # Authentication fails if no org can be determined
         org, _created = Org.objects.get_or_create(name=org_name)
         return org
 
-    def _get_teams(self, claims) -> list[tuple[str, str]]:
+    def _get_team_names(self, claims) -> list[str]:
         """
-        Get list of (display_team_name, team_name) tuples from OAuth claims.
-
-        Two-step process
-        1. OAUTH_TEAM_NAMES_FUNCTION: Extract team names from claims.
-        2. OAUTH_DISPLAY_TEAM_NAMES_FUNCTION: Map team names to display team names.
+        Extract the raw team (group) names from OAuth claims.
 
         Returns:
-            List of (display_team_name, team_name) tuples, or empty list if none.
+            List of team names, or empty list if none/extraction fails.
         """
-
         if not getattr(settings, "ENABLE_OAUTH_GROUP_MANAGEMENT", False):
             return []
 
@@ -62,10 +54,22 @@ class OIDCBackend(OIDCAuthenticationBackend):
             log.exception("Error calling OAUTH_TEAM_NAMES_FUNCTION: %s", e)
             return []
 
-        if team_names is None or not isinstance(team_names, list):
+        if not isinstance(team_names, list):
             log.error("OAUTH_TEAM_NAMES_FUNCTION must return a list of strings")
             return []
 
+        return team_names
+
+    def _get_teams(self, team_names: list[str]) -> list[tuple[str, str]]:
+        """
+        Map raw team names to (display_team_name, team_name) tuples.
+
+        Delegates to settings.OAUTH_DISPLAY_TEAM_NAMES_FUNCTION, which maps each
+        extracted team name to its display team name.
+
+        Returns:
+            List of (display_team_name, team_name) tuples, or empty list if none.
+        """
         map_func = getattr(settings, "OAUTH_DISPLAY_TEAM_NAMES_FUNCTION", lambda names: None)
 
         try:
@@ -89,7 +93,27 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
         return team_mappings
 
-    def _sync_teams(self, user: User, profile: UserProfile, claims: dict) -> None:
+    def _update_user_role(self, user: User, profile: UserProfile, team_names: list[str]):
+        """
+        Sync the user's role from the raw OAuth team (group) names.
+
+        A user is an admin if their raw team name appears in settings.ADMIN_GROUP.
+        Otherwise they fall back to the regular 'user' role. Staff/superuser
+        flags on the Django User are derived from admin status.
+
+        Note: admin determination uses the raw team/group name extracted from
+        the claims (same as team sync), not the display team name.
+        """
+        is_admin = bool(getattr(settings, "ADMIN_GROUP", None) in team_names)
+
+        profile.group = "admin" if is_admin else "user"
+        profile.save()
+
+        user.is_staff = is_admin
+        user.is_superuser = is_admin
+        user.save()
+
+    def _sync_team_membership(self, user: User, profile: UserProfile, team_names: list[str]):
         """
         Synchronize team membership based on OAuth claims.
 
@@ -103,9 +127,10 @@ class OIDCBackend(OIDCAuthenticationBackend):
         if not getattr(settings, "ENABLE_OAUTH_GROUP_MANAGEMENT", False):
             return
 
-        team_mappings = self._get_teams(claims)
-        if not team_mappings:
+        if not team_names:
             return
+
+        team_mappings = self._get_teams(team_names=team_names)
 
         org = profile.org
         with transaction.atomic():
@@ -206,7 +231,6 @@ class OIDCBackend(OIDCAuthenticationBackend):
                     )
 
     def create_user(self, claims) -> User | None:
-        groups = self._groups(claims)
         org = self._org(claims)
         if not org:
             return None  # Authentication fails if no org can be determined
@@ -214,61 +238,30 @@ class OIDCBackend(OIDCAuthenticationBackend):
         user = super().create_user(claims)
         profile = UserProfile.objects.create(user=user, org=org)
 
-        # Check if user is admin
-        if hasattr(settings, "ADMIN_GROUP"):
-            is_admin = settings.ADMIN_GROUP in groups
-        else:
-            is_admin = False
-        user.is_staff = is_admin
-        user.is_superuser = is_admin
-        if is_admin:
-            profile.group = "admin"
-        else:
-            profile.group = "user"
+        team_names = self._get_team_names(claims)
 
-        user.save()
-        profile.save()
+        self._update_user_role(user, profile, team_names)
 
         log.info("Created user '%s' (%s)", user.email, profile.group)
 
-        # Sync team membership from OAuth claims
-        self._sync_teams(user, profile, claims)
+        self._sync_team_membership(user, profile, team_names)
 
         return user
 
     def update_user(self, user, claims) -> User:
         """Update existing user with new claims, if necessary save, and return user"""
-        groups = self._groups(claims)
         org = self._org(claims)
+        if not org:
+            return user  # Authentication fails if no org can be determined
 
-        try:
-            profile = UserProfile.objects.get(user=user)
-            if profile.org != org:
-                profile.org = org
-                profile.save()
-        except UserProfile.DoesNotExist:
-            profile = UserProfile.objects.create(user=user, org=org)
+        profile, _ = UserProfile.objects.update_or_create(user=user, defaults={"org": org})
 
-        # Check if user is admin
-        if hasattr(settings, "ADMIN_GROUP"):
-            is_admin = settings.ADMIN_GROUP in groups
-        else:
-            is_admin = False
+        team_names = self._get_team_names(claims)
 
-        if is_admin:
-            profile.group = "admin"
-        elif user.is_superuser:
-            # If user was admin make them "user"
-            profile.group = "user"
-
-        user.is_staff = is_admin
-        user.is_superuser = is_admin
-        user.save()
-        profile.save()
+        self._update_user_role(user, profile, team_names)
 
         log.info("Updated user '%s' (%s)", user.email, profile.group)
 
-        # Sync team membership from OAuth claims
-        self._sync_teams(user, profile, claims)
+        self._sync_team_membership(user, profile, team_names)
 
         return user

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -74,9 +74,6 @@ class OIDCBackend(OIDCAuthenticationBackend):
             log.exception("Error calling OAUTH_DISPLAY_TEAM_NAMES_FUNCTION: %s", e)
             return []
 
-        if result is None:
-            return []
-
         if not isinstance(result, list):
             log.error("OAUTH_DISPLAY_TEAM_NAMES_FUNCTION must return a list of tuples")
             return []

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -44,39 +44,54 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
     def _get_teams(self, claims) -> list[tuple[str, str]]:
         """
-        Get list of (team_name, original_group_name) tuples from OAuth claims.
-        Calls OAUTH_TEAM_NAMES_FUNCTION setting with the full claims dict.
+        Get list of (display_team_name, team_name) tuples from OAuth claims.
+
+        Two-step process
+        1. OAUTH_TEAM_NAMES_FUNCTION: Extract team names from claims.
+        2. OAUTH_DISPLAY_TEAM_NAMES_FUNCTION: Map team names to display team names.
 
         Returns:
-            List of (team_name, original_group_name) tuples, or empty list if none.
+            List of (display_team_name, team_name) tuples, or empty list if none.
         """
 
         if not getattr(settings, "ENABLE_OAUTH_GROUP_MANAGEMENT", False):
             return []
 
-        func = getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", lambda claims: None)
+        extract_func = getattr(settings, "OAUTH_TEAM_NAMES_FUNCTION", lambda claims: None)
 
         try:
-            result = func(claims)
+            team_names = extract_func(claims)
         except Exception as e:
             log.exception("Error calling OAUTH_TEAM_NAMES_FUNCTION: %s", e)
+            return []
+
+        if team_names is None or not isinstance(team_names, list):
+            log.error("OAUTH_TEAM_NAMES_FUNCTION must return a list of strings")
+            return []
+
+        map_func = getattr(settings, "OAUTH_DISPLAY_TEAM_NAMES_FUNCTION", lambda names: None)
+
+        try:
+            result = map_func(team_names)
+        except Exception as e:
+            log.exception("Error calling OAUTH_DISPLAY_TEAM_NAMES_FUNCTION: %s", e)
             return []
 
         if result is None:
             return []
 
         if not isinstance(result, list):
-            log.error("OAUTH_TEAM_NAMES_FUNCTION must return a list of tuples")
+            log.error("OAUTH_DISPLAY_TEAM_NAMES_FUNCTION must return a list of tuples")
             return []
 
         team_mappings = []
         for item in result:
             if not isinstance(item, tuple) or len(item) != 2:  # noqa: PLR2004
                 continue
-            team_name, original_group_name = item
-            if not (team_name and isinstance(team_name, str) and original_group_name):
+            display_team_name, team_name = item
+            if not (display_team_name and isinstance(display_team_name, str) and team_name):
                 continue
-            team_mappings.append((team_name.strip(), original_group_name.strip()))
+            team_mappings.append((display_team_name.strip(), team_name.strip()))
 
         return team_mappings
 

--- a/aqueduct/management/auth.py
+++ b/aqueduct/management/auth.py
@@ -44,14 +44,13 @@ class OIDCBackend(OIDCAuthenticationBackend):
 
     def _get_teams(self, claims) -> list[tuple[str, str]]:
         """
-        Get list of (team_name, original_group_name) tuples to create/join from OAuth claims.
+        Get list of (team_name, original_group_name) tuples from OAuth claims.
         Calls OAUTH_TEAM_NAMES_FUNCTION setting with the full claims dict.
-        The function should return a list of (team_name, original_group_name) tuples,
-        or empty list to skip team creation.
 
         Returns:
-            List of tuples: [(transformed_team_name, original_oauth_group_name), ...]
+            List of (team_name, original_group_name) tuples, or empty list if none.
         """
+
         if not getattr(settings, "ENABLE_OAUTH_GROUP_MANAGEMENT", False):
             return []
 

--- a/aqueduct/management/exceptions.py
+++ b/aqueduct/management/exceptions.py
@@ -1,7 +1,0 @@
-class OAuthConfigurationError(Exception):
-    """Raised when OAuth configuration is invalid or misconfigured."""
-
-
-class OAuthFunctionError(Exception):
-    """Raised when a configured OAuth function (e.g., OAUTH_TEAM_NAMES_FUNCTION)
-    returns an invalid result or raises an exception."""

--- a/aqueduct/management/exceptions.py
+++ b/aqueduct/management/exceptions.py
@@ -1,0 +1,7 @@
+class OAuthConfigurationError(Exception):
+    """Raised when OAuth configuration is invalid or misconfigured."""
+
+
+class OAuthFunctionError(Exception):
+    """Raised when a configured OAuth function (e.g., OAUTH_TEAM_NAMES_FUNCTION)
+    returns an invalid result or raises an exception."""

--- a/aqueduct/management/tests/helpers.py
+++ b/aqueduct/management/tests/helpers.py
@@ -1,48 +1,110 @@
-def sample_team_names(claims) -> list[tuple[str, str]]:
+def sample_extract_teams(claims) -> list[str]:
     """
-    Sample implementation that filters groups starting with 'E'
-    and extracts team names (removes suffix after dash).
-    Returns list of (team_name, original_group_name) tuples.
-    Example: {'groups': ['E123-Students']} -> [('E123', 'E123-Students')]
+    Sample implementation that extracts team names from claims.
+    Filters groups starting with 'E'.
+    Example: {'groups': ['E123-Students', 'Other']} -> ['E123-Students']
     """
     groups = claims.get("groups") or []
+    return [group for group in groups if group.startswith("E")]
+
+
+def sample_map_team_names(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Sample implementation that maps team names to display team names.
+    Extracts team names (removes suffix after dash).
+    Example: ['E123-Students'] -> [('E123', 'E123-Students')]
+    """
     result = []
-    for group in groups:
-        if group.startswith("E"):
-            team_name = group.split("-", maxsplit=1)[0]
-            result.append((team_name, group))
+    for team_name in team_names:
+        display_team_name = team_name.split("-", maxsplit=1)[0]
+        result.append((display_team_name, team_name))
     return result
 
 
-def team_names_keep_full(claims) -> list[tuple[str, str]]:
+def sample_team_names(claims) -> list[tuple[str, str]]:
     """
-    Helper that keeps full group name as team name.
-    Example: {'groups': ['E123-Students']} -> [('E123-Students', 'E123-Students')]
+    Backward compatibility wrapper. Use sample_extract_teams + sample_map_team_names instead.
+    """
+    team_names = sample_extract_teams(claims)
+    return sample_map_team_names(team_names)
+
+
+def extract_teams_keep_full(claims) -> list[str]:
+    """
+    Extract team names, keeping full group name.
+    Example: {'groups': ['E123-Students']} -> ['E123-Students']
     """
     groups = claims.get("groups") or []
-    return [(group, group) for group in groups if group.startswith("E")]
+    return [group for group in groups if group.startswith("E")]
+
+
+def map_team_names_keep_full(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Map team names keeping full name as display team name.
+    Example: ['E123-Students'] -> [('E123-Students', 'E123-Students')]
+    """
+    return [(group, group) for group in team_names]
+
+
+def extract_teams_with_prefix(claims) -> list[str]:
+    """
+    Extract team names starting with 'E'.
+    Example: {'groups': ['E123-Students']} -> ['E123-Students']
+    """
+    groups = claims.get("groups") or []
+    return [group for group in groups if group.startswith("E")]
+
+
+def map_team_names_with_prefix(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Map team names adding 'Team-' prefix.
+    Example: ['E123-Students'] -> [('Team-E123-Students', 'E123-Students')]
+    """
+    return [(f"Team-{group}", group) for group in team_names]
+
+
+def extract_teams_strip_suffix(claims) -> list[str]:
+    """
+    Extract team names starting with 'E'.
+    Example: {'groups': ['E123-Students']} -> ['E123-Students']
+    """
+    groups = claims.get("groups") or []
+    return [group for group in groups if group.startswith("E")]
+
+
+def map_team_names_strip_suffix(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Map team names stripping suffix after dash.
+    Example: ['E123-Students'] -> [('E123', 'E123-Students')]
+    """
+    return [(group.split("-", maxsplit=1)[0], group) for group in team_names]
+
+
+def extract_teams_empty(claims) -> list[str]:
+    """
+    Extract no team names (causes deletion).
+    """
+    return []
+
+
+def map_team_names_empty(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Map to empty list (causes deletion).
+    """
+    return []
+
+
+def team_names_keep_full(claims) -> list[tuple[str, str]]:
+    return map_team_names_keep_full(extract_teams_keep_full(claims))
 
 
 def team_names_with_prefix(claims) -> list[tuple[str, str]]:
-    """
-    Sample function that adds 'Team-' prefix to group names.
-    Example: {'groups': ['E123-Students']} -> [('Team-E123-Students', 'E123-Students')]
-    """
-    groups = claims.get("groups") or []
-    return [(f"Team-{group}", group) for group in groups if group.startswith("E")]
+    return map_team_names_with_prefix(extract_teams_with_prefix(claims))
 
 
 def team_names_strip_suffix(claims) -> list[tuple[str, str]]:
-    """
-    Sample function that strips suffix after dash.
-    Example: {'groups': ['E123-Students']} -> [('E123', 'E123-Students')]
-    """
-    groups = claims.get("groups") or []
-    return [(group.split("-", maxsplit=1)[0], group) for group in groups if group.startswith("E")]
+    return map_team_names_strip_suffix(extract_teams_strip_suffix(claims))
 
 
 def team_names_empty(claims) -> list[tuple[str, str]]:
-    """
-    Sample function that returns empty list (causes deletion).
-    """
     return []

--- a/aqueduct/management/tests/helpers.py
+++ b/aqueduct/management/tests/helpers.py
@@ -1,0 +1,78 @@
+"""
+Shared test helpers for management app tests.
+"""
+
+
+def sample_team_names(claims) -> list[tuple[str, str]]:
+    """
+    Sample implementation that filters groups starting with 'E'
+    and extracts team names (removes suffix after dash).
+    Returns list of (team_name, original_group_name) tuples.
+    Example: {'groups': ['E123-Students']} -> [('E123', 'E123-Students')]
+    """
+    groups = claims.get("groups") or []
+    result = []
+    for group in groups:
+        if group.startswith("E"):
+            team_name = group.split("-", maxsplit=1)[0]
+            result.append((team_name, group))
+    return result
+
+
+def team_names_keep_full(claims) -> list[tuple[str, str]]:
+    """
+    Helper that keeps full group name as team name.
+    Example: {'groups': ['E123-Students']} -> [('E123-Students', 'E123-Students')]
+    """
+    groups = claims.get("groups") or []
+    result = []
+    for group in groups:
+        if group.startswith("E"):
+            result.append((group, group))
+    return result
+
+
+def team_names_with_prefix(claims) -> list[tuple[str, str]]:
+    """
+    Sample function that adds 'Team-' prefix to group names.
+    Example: {'groups': ['E123-Students']} -> [('Team-E123-Students', 'E123-Students')]
+    """
+    groups = claims.get("groups") or []
+    result = []
+    for group in groups:
+        if group.startswith("E"):
+            result.append((f"Team-{group}", group))
+    return result
+
+
+def team_names_strip_suffix(claims) -> list[tuple[str, str]]:
+    """
+    Sample function that strips suffix after dash.
+    Example: {'groups': ['E123-Students']} -> [('E123', 'E123-Students')]
+    """
+    groups = claims.get("groups") or []
+    result = []
+    for group in groups:
+        if group.startswith("E"):
+            result.append((group.split("-", maxsplit=1)[0], group))
+    return result
+
+
+def team_names_empty(claims) -> list[tuple[str, str]]:
+    """
+    Sample function that returns empty list (causes deletion).
+    """
+    return []
+
+
+def custom_filter_team_names(claims) -> list[tuple[str, str]]:
+    """
+    Custom filter that only allows specific group names.
+    Example: {'groups': ['E123', 'E456', 'E789']} -> [('E123', 'E123'), ('E456', 'E456')]
+    """
+    groups = claims.get("groups") or []
+    result = []
+    for group in groups:
+        if group in {"E123", "E456"}:
+            result.append((group, group))
+    return result

--- a/aqueduct/management/tests/helpers.py
+++ b/aqueduct/management/tests/helpers.py
@@ -1,8 +1,3 @@
-"""
-Shared test helpers for management app tests.
-"""
-
-
 def sample_team_names(claims) -> list[tuple[str, str]]:
     """
     Sample implementation that filters groups starting with 'E'

--- a/aqueduct/management/tests/helpers.py
+++ b/aqueduct/management/tests/helpers.py
@@ -25,11 +25,7 @@ def team_names_keep_full(claims) -> list[tuple[str, str]]:
     Example: {'groups': ['E123-Students']} -> [('E123-Students', 'E123-Students')]
     """
     groups = claims.get("groups") or []
-    result = []
-    for group in groups:
-        if group.startswith("E"):
-            result.append((group, group))
-    return result
+    return [(group, group) for group in groups if group.startswith("E")]
 
 
 def team_names_with_prefix(claims) -> list[tuple[str, str]]:
@@ -38,11 +34,7 @@ def team_names_with_prefix(claims) -> list[tuple[str, str]]:
     Example: {'groups': ['E123-Students']} -> [('Team-E123-Students', 'E123-Students')]
     """
     groups = claims.get("groups") or []
-    result = []
-    for group in groups:
-        if group.startswith("E"):
-            result.append((f"Team-{group}", group))
-    return result
+    return [(f"Team-{group}", group) for group in groups if group.startswith("E")]
 
 
 def team_names_strip_suffix(claims) -> list[tuple[str, str]]:
@@ -51,11 +43,7 @@ def team_names_strip_suffix(claims) -> list[tuple[str, str]]:
     Example: {'groups': ['E123-Students']} -> [('E123', 'E123-Students')]
     """
     groups = claims.get("groups") or []
-    result = []
-    for group in groups:
-        if group.startswith("E"):
-            result.append((group.split("-", maxsplit=1)[0], group))
-    return result
+    return [(group.split("-", maxsplit=1)[0], group) for group in groups if group.startswith("E")]
 
 
 def team_names_empty(claims) -> list[tuple[str, str]]:
@@ -63,16 +51,3 @@ def team_names_empty(claims) -> list[tuple[str, str]]:
     Sample function that returns empty list (causes deletion).
     """
     return []
-
-
-def custom_filter_team_names(claims) -> list[tuple[str, str]]:
-    """
-    Custom filter that only allows specific group names.
-    Example: {'groups': ['E123', 'E456', 'E789']} -> [('E123', 'E123'), ('E456', 'E456')]
-    """
-    groups = claims.get("groups") or []
-    result = []
-    for group in groups:
-        if group in {"E123", "E456"}:
-            result.append((group, group))
-    return result

--- a/aqueduct/management/tests/test_get_teams_from_groups.py
+++ b/aqueduct/management/tests/test_get_teams_from_groups.py
@@ -4,15 +4,9 @@ from django.test import TestCase, override_settings
 
 from management.auth import OIDCBackend
 from management.models import Org
+from management.tests.helpers import sample_team_names
 
 User = get_user_model()
-
-
-def sample_team_names(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-    if group.startswith("E"):
-        team_name = group.split("-", maxsplit=1)[0]
-        return (team_name, group)
-    return None
 
 
 @override_settings(

--- a/aqueduct/management/tests/test_get_teams_from_groups.py
+++ b/aqueduct/management/tests/test_get_teams_from_groups.py
@@ -4,7 +4,7 @@ from django.test import TestCase, override_settings
 
 from management.auth import OIDCBackend
 from management.models import Org
-from management.tests.helpers import sample_team_names
+from management.tests.helpers import sample_extract_teams, sample_map_team_names
 
 User = get_user_model()
 
@@ -12,7 +12,8 @@ User = get_user_model()
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_extract_teams,
+    OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=sample_map_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )

--- a/aqueduct/management/tests/test_get_teams_from_groups.py
+++ b/aqueduct/management/tests/test_get_teams_from_groups.py
@@ -8,7 +8,7 @@ from management.models import Org
 User = get_user_model()
 
 
-def sample_team_names_from_groups(
+def sample_team_names(
     group: str, groups: list[str] | None = None
 ) -> tuple[str, str] | None:
     if group.startswith("E"):
@@ -20,7 +20,7 @@ def sample_team_names_from_groups(
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names_from_groups,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -65,78 +65,6 @@ class GetTeamsFromGroupsTestCase(TestCase):
         result = self.backend._get_teams(claims)
 
         self.assertEqual(result, [])
-
-    def test_get_teams_feature_disabled(self):
-        """Test that empty list is returned when feature is disabled."""
-        with override_settings(ENABLE_OAUTH_GROUP_MANAGEMENT=False):
-            backend = OIDCBackend()
-            claims = {"email": "test@example.com", "groups": ["E123-Students"]}
-
-            result = backend._get_teams(claims)
-
-            self.assertEqual(result, [])
-
-    def test_get_teams_filters_invalid_results(self):
-        """Test that invalid return values from function are filtered out."""
-
-        def bad_function(group, groups=None):
-            if group == "valid":
-                return ("ValidTeam", "valid")
-            elif group == "wrong_type":
-                return "not-a-tuple"
-            elif group == "wrong_length":
-                return ("only", "one", "extra")
-            elif group == "empty_team":
-                return ("", "empty_team")
-            elif group == "none_team":
-                return (None, "none_team")
-            return None
-
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=bad_function):
-            backend = OIDCBackend()
-            claims = {
-                "email": "test@example.com",
-                "groups": ["valid", "wrong_type", "wrong_length", "empty_team", "none_team"],
-            }
-
-            result = backend._get_teams(claims)
-
-            self.assertEqual(len(result), 1)
-            self.assertEqual(result[0], ("ValidTeam", "valid"))
-
-    def test_get_teams_function_raises_exception(self):
-        """Test that exceptions in function are caught and logged."""
-
-        def raising_function(group, groups=None):
-            if group == "error":
-                raise ValueError("Test error")
-            return ("ValidTeam", group)
-
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=raising_function):
-            backend = OIDCBackend()
-            claims = {"email": "test@example.com", "groups": ["valid", "error", "valid2"]}
-
-            result = backend._get_teams(claims)
-
-            # Should have 2 valid results, skipping the one that raised exception
-            self.assertEqual(len(result), 2)
-            self.assertEqual(result[0], ("ValidTeam", "valid"))
-            self.assertEqual(result[1], ("ValidTeam", "valid2"))
-
-    def test_get_teams_strips_whitespace(self):
-        """Test that team names and group names are stripped of whitespace."""
-
-        def whitespace_function(group, groups=None):
-            return ("  TeamName  ", "  GroupName  ")
-
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=whitespace_function):
-            backend = OIDCBackend()
-            claims = {"email": "test@example.com", "groups": ["test-group"]}
-
-            result = backend._get_teams(claims)
-
-            self.assertEqual(len(result), 1)
-            self.assertEqual(result[0], ("TeamName", "GroupName"))
 
     def test_get_teams_no_function_configured(self):
         """Test handling when no function is configured."""

--- a/aqueduct/management/tests/test_get_teams_from_groups.py
+++ b/aqueduct/management/tests/test_get_teams_from_groups.py
@@ -1,0 +1,151 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import TestCase, override_settings
+
+from management.auth import OIDCBackend
+from management.models import Org
+
+User = get_user_model()
+
+
+def sample_team_names_from_groups(
+    group: str, groups: list[str] | None = None
+) -> tuple[str, str] | None:
+    if group.startswith("E"):
+        team_name = group.split("-", maxsplit=1)[0]
+        return (team_name, group)
+    return None
+
+
+@override_settings(
+    ENABLE_OAUTH_GROUP_MANAGEMENT=True,
+    ENABLE_OAUTH_GROUP_CREATION=True,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names_from_groups,
+    OIDC_RP_SIGN_ALGO="HS256",
+    OIDC_RP_IDP_SIGN_KEY="test-key",
+)
+class GetTeamsFromGroupsTestCase(TestCase):
+    """Test _get_teams method."""
+
+    def setUp(self):
+        self.backend = OIDCBackend()
+        self.org = Org.objects.create(name="test-org")
+        self.user_group, _ = Group.objects.get_or_create(name="user")
+
+    def test_get_teams_with_valid_claims(self):
+        """Test extracting teams from valid claims dict."""
+        claims = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
+
+        result = self.backend._get_teams(claims)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], ("E123", "E123-Students"))
+        self.assertEqual(result[1], ("E456", "E456-Staff"))
+
+    def test_get_teams_with_empty_groups(self):
+        """Test handling of empty groups list in claims."""
+        claims = {"email": "test@example.com", "groups": []}
+
+        result = self.backend._get_teams(claims)
+
+        self.assertEqual(result, [])
+
+    def test_get_teams_with_missing_groups_key(self):
+        """Test handling of missing 'groups' key in claims."""
+        claims = {"email": "test@example.com"}
+
+        result = self.backend._get_teams(claims)
+
+        self.assertEqual(result, [])
+
+    def test_get_teams_with_none_groups(self):
+        """Test handling of None groups value in claims."""
+        claims = {"email": "test@example.com", "groups": None}
+
+        result = self.backend._get_teams(claims)
+
+        self.assertEqual(result, [])
+
+    def test_get_teams_feature_disabled(self):
+        """Test that empty list is returned when feature is disabled."""
+        with override_settings(ENABLE_OAUTH_GROUP_MANAGEMENT=False):
+            backend = OIDCBackend()
+            claims = {"email": "test@example.com", "groups": ["E123-Students"]}
+
+            result = backend._get_teams(claims)
+
+            self.assertEqual(result, [])
+
+    def test_get_teams_filters_invalid_results(self):
+        """Test that invalid return values from function are filtered out."""
+
+        def bad_function(group, groups=None):
+            if group == "valid":
+                return ("ValidTeam", "valid")
+            elif group == "wrong_type":
+                return "not-a-tuple"
+            elif group == "wrong_length":
+                return ("only", "one", "extra")
+            elif group == "empty_team":
+                return ("", "empty_team")
+            elif group == "none_team":
+                return (None, "none_team")
+            return None
+
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=bad_function):
+            backend = OIDCBackend()
+            claims = {
+                "email": "test@example.com",
+                "groups": ["valid", "wrong_type", "wrong_length", "empty_team", "none_team"],
+            }
+
+            result = backend._get_teams(claims)
+
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0], ("ValidTeam", "valid"))
+
+    def test_get_teams_function_raises_exception(self):
+        """Test that exceptions in function are caught and logged."""
+
+        def raising_function(group, groups=None):
+            if group == "error":
+                raise ValueError("Test error")
+            return ("ValidTeam", group)
+
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=raising_function):
+            backend = OIDCBackend()
+            claims = {"email": "test@example.com", "groups": ["valid", "error", "valid2"]}
+
+            result = backend._get_teams(claims)
+
+            # Should have 2 valid results, skipping the one that raised exception
+            self.assertEqual(len(result), 2)
+            self.assertEqual(result[0], ("ValidTeam", "valid"))
+            self.assertEqual(result[1], ("ValidTeam", "valid2"))
+
+    def test_get_teams_strips_whitespace(self):
+        """Test that team names and group names are stripped of whitespace."""
+
+        def whitespace_function(group, groups=None):
+            return ("  TeamName  ", "  GroupName  ")
+
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=whitespace_function):
+            backend = OIDCBackend()
+            claims = {"email": "test@example.com", "groups": ["test-group"]}
+
+            result = backend._get_teams(claims)
+
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0], ("TeamName", "GroupName"))
+
+    def test_get_teams_no_function_configured(self):
+        """Test handling when no function is configured."""
+
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=None):
+            backend = OIDCBackend()
+            claims = {"email": "test@example.com", "groups": ["E123-Students"]}
+
+            # When function is None, the default lambda returns None for all groups
+            result = backend._get_teams(claims)
+
+            self.assertEqual(result, [])

--- a/aqueduct/management/tests/test_get_teams_from_groups.py
+++ b/aqueduct/management/tests/test_get_teams_from_groups.py
@@ -8,9 +8,7 @@ from management.models import Org
 User = get_user_model()
 
 
-def sample_team_names(
-    group: str, groups: list[str] | None = None
-) -> tuple[str, str] | None:
+def sample_team_names(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
     if group.startswith("E"):
         team_name = group.split("-", maxsplit=1)[0]
         return (team_name, group)

--- a/aqueduct/management/tests/test_get_teams_from_groups.py
+++ b/aqueduct/management/tests/test_get_teams_from_groups.py
@@ -1,12 +1,7 @@
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import TestCase, override_settings
 
 from management.auth import OIDCBackend
-from management.models import Org
 from management.tests.helpers import sample_extract_teams, sample_map_team_names
-
-User = get_user_model()
 
 
 @override_settings(
@@ -17,56 +12,122 @@ User = get_user_model()
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
-class GetTeamsFromGroupsTestCase(TestCase):
-    """Test _get_teams method."""
+class GetTeamNamesTestCase(TestCase):
+    """Test the _get_team_names extraction method."""
 
     def setUp(self):
         self.backend = OIDCBackend()
-        self.org = Org.objects.create(name="test-org")
-        self.user_group, _ = Group.objects.get_or_create(name="user")
 
-    def test_get_teams_with_valid_claims(self):
-        """Test extracting teams from valid claims dict."""
+    def test_extracts_team_names_from_valid_claims(self):
         claims = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
 
-        result = self.backend._get_teams(claims)
+        result = self.backend._get_team_names(claims)
+
+        self.assertEqual(result, ["E123-Students", "E456-Staff"])
+
+    def test_filters_non_matching_groups(self):
+        claims = {"groups": ["E123-Students", "Other-Group", "E456-Staff"]}
+
+        result = self.backend._get_team_names(claims)
+
+        self.assertEqual(result, ["E123-Students", "E456-Staff"])
+
+    def test_empty_groups_returns_empty(self):
+        result = self.backend._get_team_names({"groups": []})
+        self.assertEqual(result, [])
+
+    def test_missing_groups_key_returns_empty(self):
+        result = self.backend._get_team_names({"email": "test@example.com"})
+        self.assertEqual(result, [])
+
+    def test_none_groups_returns_empty(self):
+        result = self.backend._get_team_names({"groups": None})
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_function_returns_non_list(self):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=lambda claims: "not-a-list"):
+            backend = OIDCBackend()
+
+            result = backend._get_team_names({"groups": ["E123-Students"]})
+
+            self.assertEqual(result, [])
+
+    def test_returns_empty_when_function_is_none(self):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=None):
+            backend = OIDCBackend()
+
+            result = backend._get_team_names({"groups": ["E123-Students"]})
+
+            self.assertEqual(result, [])
+
+    def test_returns_empty_when_function_raises(self):
+        def broken(claims):
+            raise RuntimeError("boom")
+
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=broken):
+            backend = OIDCBackend()
+
+            result = backend._get_team_names({"groups": ["E123-Students"]})
+
+            self.assertEqual(result, [])
+
+    def test_returns_empty_when_management_disabled(self):
+        with override_settings(ENABLE_OAUTH_GROUP_MANAGEMENT=False):
+            backend = OIDCBackend()
+
+            result = backend._get_team_names({"groups": ["E123-Students"]})
+
+            self.assertEqual(result, [])
+
+
+@override_settings(
+    ENABLE_OAUTH_GROUP_MANAGEMENT=True,
+    ENABLE_OAUTH_GROUP_CREATION=True,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_extract_teams,
+    OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=sample_map_team_names,
+    OIDC_RP_SIGN_ALGO="HS256",
+    OIDC_RP_IDP_SIGN_KEY="test-key",
+)
+class GetTeamsTestCase(TestCase):
+    """Test the _get_teams display-mapping method."""
+
+    def setUp(self):
+        self.backend = OIDCBackend()
+
+    def test_map_team_names(self):
+        result = self.backend._get_teams(["E123-Students", "E456-Staff"])
 
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0], ("E123", "E123-Students"))
         self.assertEqual(result[1], ("E456", "E456-Staff"))
 
-    def test_get_teams_with_empty_groups(self):
-        """Test handling of empty groups list in claims."""
-        claims = {"email": "test@example.com", "groups": []}
-
-        result = self.backend._get_teams(claims)
-
+    def test_empty_team_names_returns_empty(self):
+        result = self.backend._get_teams([])
         self.assertEqual(result, [])
 
-    def test_get_teams_with_missing_groups_key(self):
-        """Test handling of missing 'groups' key in claims."""
-        claims = {"email": "test@example.com"}
-
-        result = self.backend._get_teams(claims)
-
-        self.assertEqual(result, [])
-
-    def test_get_teams_with_none_groups(self):
-        """Test handling of None groups value in claims."""
-        claims = {"email": "test@example.com", "groups": None}
-
-        result = self.backend._get_teams(claims)
-
-        self.assertEqual(result, [])
-
-    def test_get_teams_no_function_configured(self):
-        """Test handling when no function is configured."""
-
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=None):
+    def test_returns_empty_when_function_not_configured(self):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=None):
             backend = OIDCBackend()
-            claims = {"email": "test@example.com", "groups": ["E123-Students"]}
 
-            # When function is None, the default lambda returns None for all groups
-            result = backend._get_teams(claims)
+            result = backend._get_teams(["E123-Students"])
 
             self.assertEqual(result, [])
+
+    def test_returns_empty_when_function_returns_non_list(self):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=lambda names: "nope"):
+            backend = OIDCBackend()
+
+            result = backend._get_teams(["E123-Students"])
+
+            self.assertEqual(result, [])
+
+    def test_skips_malformed_entries(self):
+        def bad_map(names):
+            return [("E123", "E123-Students"), ("bad",), (None, "x"), 42]
+
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=bad_map):
+            backend = OIDCBackend()
+
+            result = backend._get_teams(["E123-Students"])
+
+            self.assertEqual(result, [("E123", "E123-Students")])

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -12,7 +12,7 @@ from management.models import Org, Team, TeamMembership, UserProfile
 User = get_user_model()
 
 
-def sample_team_names_from_groups(
+def sample_team_names(
     group: str, groups: list[str] | None = None
 ) -> tuple[str, str] | None:
     """
@@ -30,7 +30,7 @@ def sample_team_names_from_groups(
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=sample_team_names_from_groups,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -53,7 +53,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         self.assertEqual(Team.objects.count(), 2)
         self.assertTrue(Team.objects.filter(name="E123", org=self.org).exists())
@@ -85,7 +85,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user1 = User.objects.create_user(username="user1", email="user1@example.com")
         user1.groups.add(self.user_group)
         profile1 = UserProfile.objects.create(user=user1, org=self.org)
-        self.backend._sync_teams(user1, profile1, claims["groups"])
+        self.backend._sync_teams(user1, profile1, claims)
 
         self.assertEqual(Team.objects.count(), 1)
         team = Team.objects.get(oauth_group_name="E123-Students")
@@ -97,8 +97,8 @@ class OAuthTeamCreationTestCase(TestCase):
         user2.groups.add(self.user_group)
         profile2 = UserProfile.objects.create(user=user2, org=self.org)
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_keep_full):
-            self.backend._sync_teams(user2, profile2, claims["groups"])
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_keep_full):
+            self.backend._sync_teams(user2, profile2, claims)
 
         # Should rename existing team, not create a duplicate
         self.assertEqual(Team.objects.count(), 1)
@@ -130,8 +130,8 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_keep_full):
-            self.backend._sync_teams(user, profile, claims["groups"])
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_keep_full):
+            self.backend._sync_teams(user, profile, claims)
 
         # Should NOT rename old_team (name collision with blocker)
         old_team.refresh_from_db()
@@ -151,7 +151,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         self.assertEqual(Team.objects.count(), 1)
         self.assertEqual(TeamMembership.objects.count(), 1)
@@ -169,7 +169,7 @@ class OAuthTeamCreationTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            backend._sync_teams(user, profile, claims["groups"])
+            backend._sync_teams(user, profile, claims)
 
             self.assertEqual(Team.objects.count(), 0)
             self.assertEqual(TeamMembership.objects.count(), 0)
@@ -182,7 +182,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         self.assertEqual(Team.objects.count(), 0)
         self.assertEqual(TeamMembership.objects.count(), 0)
@@ -195,7 +195,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         self.assertEqual(Team.objects.count(), 0)
         self.assertEqual(TeamMembership.objects.count(), 0)
@@ -204,7 +204,7 @@ class OAuthTeamCreationTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=sample_team_names_from_groups,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -224,7 +224,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
         self.assertEqual(memberships.count(), 2)
@@ -243,12 +243,12 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        initial_groups = ["E123-Students", "E456-Staff"]
+        initial_groups = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
         self.backend._sync_teams(user, profile, initial_groups)
 
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 2)
 
-        updated_groups = ["E123-Students"]
+        updated_groups = {"email": "test@example.com", "groups": ["E123-Students"]}
         self.backend._sync_teams(user, profile, updated_groups)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
@@ -261,7 +261,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        initial_groups = ["E123-Students", "E456-Staff"]
+        initial_groups = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
         self.backend._sync_teams(user, profile, initial_groups)
 
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 2)
@@ -271,7 +271,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         self.assertTrue(team2.managed_by_oauth)
 
         with override_settings(ENABLE_OAUTH_GROUP_REMOVAL=False):
-            updated_groups = ["E123-Students"]
+            updated_groups = {"email": "test@example.com", "groups": ["E123-Students"]}
             self.backend._sync_teams(user, profile, updated_groups)
 
             memberships = TeamMembership.objects.filter(user_profile=profile)
@@ -295,7 +295,7 @@ class OAuthTeamMembershipTestCase(TestCase):
 
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 2)
 
-        updated_groups = ["E123-Students", "OtherGroup"]
+        updated_groups = {"email": "test@example.com", "groups": ["E123-Students", "OtherGroup"]}
         self.backend._sync_teams(user, profile, updated_groups)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
@@ -312,12 +312,12 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims_initial["groups"])
+        self.backend._sync_teams(user, profile, claims_initial)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 1)
 
         claims_updated = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
 
-        self.backend._sync_teams(user, profile, claims_updated["groups"])
+        self.backend._sync_teams(user, profile, claims_updated)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
         self.assertEqual(memberships.count(), 2)
@@ -334,7 +334,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         team = Team.objects.filter(name="E123").first()
         self.assertIsNotNone(team)
@@ -347,7 +347,7 @@ class OAuthTeamMembershipTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=sample_team_names_from_groups,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -372,8 +372,8 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user2.groups.add(self.user_group)
         profile2 = UserProfile.objects.create(user=user2, org=self.other_org)
 
-        self.backend._sync_teams(user1, profile1, claims["groups"])
-        self.backend._sync_teams(user2, profile2, claims["groups"])
+        self.backend._sync_teams(user1, profile1, claims)
+        self.backend._sync_teams(user2, profile2, claims)
 
         self.assertEqual(Team.objects.filter(name="E123").count(), 2)
 
@@ -395,7 +395,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         self.assertEqual(Team.objects.count(), 3)
         team_names = {t.name for t in Team.objects.all()}
@@ -411,7 +411,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         team = Team.objects.first()
         self.assertIsNotNone(team)
@@ -424,7 +424,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         self.assertEqual(Team.objects.count(), 2)
         team_names = {t.name for t in Team.objects.all()}
@@ -434,7 +434,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=lambda group, groups=None: None,
+    OAUTH_TEAM_NAMES_FUNCTION=lambda group, groups=None: None,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -454,7 +454,7 @@ class OAuthTeamSettingsTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         self.assertEqual(Team.objects.count(), 0)
         self.assertEqual(TeamMembership.objects.count(), 0)
@@ -467,7 +467,7 @@ class OAuthTeamSettingsTestCase(TestCase):
                 return (group, group)
             return None
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=custom_filter):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=custom_filter):
             backend = OIDCBackend()
             claims = {"email": "test@example.com", "groups": ["E123", "E456", "E789"]}
 
@@ -475,7 +475,7 @@ class OAuthTeamSettingsTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            backend._sync_teams(user, profile, claims["groups"])
+            backend._sync_teams(user, profile, claims)
 
             self.assertEqual(Team.objects.count(), 2)
             team_names = {t.name for t in Team.objects.all()}
@@ -491,7 +491,7 @@ class OAuthTeamSettingsTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            backend._sync_teams(user, profile, claims["groups"])
+            backend._sync_teams(user, profile, claims)
 
             self.assertEqual(Team.objects.count(), 0)
             self.assertEqual(TeamMembership.objects.count(), 0)
@@ -505,7 +505,7 @@ class OAuthTeamSettingsTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            self.backend._sync_teams(user, profile, claims["groups"])
+            self.backend._sync_teams(user, profile, claims)
 
             self.assertEqual(Team.objects.count(), 0)
             self.assertEqual(TeamMembership.objects.count(), 0)
@@ -520,7 +520,7 @@ class OAuthTeamSettingsTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims["groups"])
+        self.backend._sync_teams(user, profile, claims)
 
         manual_team.refresh_from_db()
         self.assertEqual(manual_team.oauth_group_name, "")
@@ -530,7 +530,7 @@ class OAuthTeamSettingsTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=sample_team_names_from_groups,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -574,7 +574,7 @@ class OAuthTeamIntegrationTestCase(TestCase):
 
         initial_claims = {"email": "test@example.com", "groups": ["E123-Students"]}
 
-        self.backend._sync_teams(user, profile, initial_claims["groups"])
+        self.backend._sync_teams(user, profile, initial_claims)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 1)
 
         updated_claims = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -8,13 +8,16 @@ from django.test import TestCase, override_settings
 
 from management.auth import OIDCBackend
 from management.models import Org, Team, TeamMembership, UserProfile
-from management.tests.helpers import (
-    custom_filter_team_names,
-    sample_team_names,
-    team_names_keep_full,
-)
+from management.tests.helpers import sample_team_names, team_names_keep_full
 
 User = get_user_model()
+
+
+def custom_filter_team_names(claims) -> list[tuple[str, str]]:
+    """
+    Custom filter that only allows specific group names.
+    """
+    return [("E123", "E123"), ("E456", "E456")]
 
 
 @override_settings(

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -8,21 +8,13 @@ from django.test import TestCase, override_settings
 
 from management.auth import OIDCBackend
 from management.models import Org, Team, TeamMembership, UserProfile
+from management.tests.helpers import (
+    custom_filter_team_names,
+    sample_team_names,
+    team_names_keep_full,
+)
 
 User = get_user_model()
-
-
-def sample_team_names(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-    """
-    Sample implementation that filters groups starting with 'E'
-    and extracts team names (removes suffix after dash).
-    Returns tuple of (team_name, original_group_name) or None to skip.
-    Example: 'E123-Students' -> ('E123', 'E123-Students')
-    """
-    if group.startswith("E"):
-        team_name = group.split("-", maxsplit=1)[0]
-        return (team_name, group)
-    return None
 
 
 @override_settings(
@@ -71,12 +63,6 @@ class OAuthTeamCreationTestCase(TestCase):
     def test_rename_team_when_mapping_changes(self):
         """Test that existing OAuth teams are renamed (not duplicated) when mapping changes."""
 
-        # Helper: keeps full group name as team name (opposite of sample_team_names)
-        def team_names_keep_full(group: str, groups: list[str] | None = None):
-            if group.startswith("E"):
-                return (group, group)
-            return None
-
         claims = {"email": "test@example.com", "groups": ["E123-Students"]}
 
         # Step 1: Create team with old mapping (strips suffix: "E123-Students" -> "E123")
@@ -110,11 +96,6 @@ class OAuthTeamCreationTestCase(TestCase):
 
     def test_name_collision_prevents_rename(self):
         """Test that rename is skipped when target name already exists."""
-
-        def team_names_keep_full(group: str, groups: list[str] | None = None):
-            if group.startswith("E"):
-                return (group, group)
-            return None
 
         # Create team with old mapping name
         old_team = Team.objects.create(name="E123", org=self.org, oauth_group_name="E123-Students")
@@ -432,7 +413,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FUNCTION=lambda group, groups=None: None,
+    OAUTH_TEAM_NAMES_FUNCTION=lambda claims: [],
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -460,12 +441,7 @@ class OAuthTeamSettingsTestCase(TestCase):
     def test_custom_filter_function(self):
         """Test custom filter function."""
 
-        def custom_filter(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-            if group in {"E123", "E456"}:
-                return (group, group)
-            return None
-
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=custom_filter):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=custom_filter_team_names):
             backend = OIDCBackend()
             claims = {"email": "test@example.com", "groups": ["E123", "E456", "E789"]}
 

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -73,7 +73,7 @@ class OAuthTeamCreationTestCase(TestCase):
     def test_rename_team_when_mapping_changes(self):
         """Test that existing OAuth teams are renamed (not duplicated) when mapping changes."""
 
-        # Helper: keeps full group name as team name (opposite of sample_team_names_from_groups)
+        # Helper: keeps full group name as team name (opposite of sample_team_names)
         def team_names_keep_full(group: str, groups: list[str] | None = None):
             if group.startswith("E"):
                 return (group, group)

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -48,7 +48,7 @@ class OAuthTeamCreationTestCase(TestCase):
 
         self.backend._sync_teams(user, profile, claims)
 
-        self.assertEqual(Team.objects.count(), 2)
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 2)
         self.assertTrue(Team.objects.filter(name="E123", org=self.org).exists())
         self.assertTrue(Team.objects.filter(name="E456", org=self.org).exists())
         self.assertFalse(Team.objects.filter(name="Other-Group", org=self.org).exists())
@@ -74,8 +74,8 @@ class OAuthTeamCreationTestCase(TestCase):
         profile1 = UserProfile.objects.create(user=user1, org=self.org)
         self.backend._sync_teams(user1, profile1, claims)
 
-        self.assertEqual(Team.objects.count(), 1)
-        team = Team.objects.get(oauth_group_name="E123-Students")
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 1)
+        team = Team.objects.get(oauth_group_name="E123-Students", org=self.org)
         self.assertEqual(team.name, "E123")
 
         # Step 2: New user logs in with new mapping
@@ -88,7 +88,7 @@ class OAuthTeamCreationTestCase(TestCase):
             self.backend._sync_teams(user2, profile2, claims)
 
         # Should rename existing team, not create a duplicate
-        self.assertEqual(Team.objects.count(), 1)
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 1)
         team.refresh_from_db()
         self.assertEqual(team.name, "E123-Students")
         self.assertEqual(team.oauth_group_name, "E123-Students")
@@ -135,9 +135,9 @@ class OAuthTeamCreationTestCase(TestCase):
 
         self.backend._sync_teams(user, profile, claims)
 
-        self.assertEqual(Team.objects.count(), 1)
-        self.assertEqual(TeamMembership.objects.count(), 1)
-        self.assertEqual(TeamMembership.objects.first().team, team)
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 1)
+        self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 1)
+        self.assertEqual(TeamMembership.objects.filter(user_profile=profile).first().team, team)
         self.assertEqual(team.oauth_group_name, "")
         self.assertFalse(team.managed_by_oauth)
 
@@ -153,8 +153,8 @@ class OAuthTeamCreationTestCase(TestCase):
 
             backend._sync_teams(user, profile, claims)
 
-            self.assertEqual(Team.objects.count(), 0)
-            self.assertEqual(TeamMembership.objects.count(), 0)
+            self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
+            self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
 
     def test_empty_groups_list(self):
         """Test handling of empty groups list."""
@@ -166,8 +166,8 @@ class OAuthTeamCreationTestCase(TestCase):
 
         self.backend._sync_teams(user, profile, claims)
 
-        self.assertEqual(Team.objects.count(), 0)
-        self.assertEqual(TeamMembership.objects.count(), 0)
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
+        self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
 
     def test_none_groups(self):
         """Test handling of None groups."""
@@ -179,8 +179,8 @@ class OAuthTeamCreationTestCase(TestCase):
 
         self.backend._sync_teams(user, profile, claims)
 
-        self.assertEqual(Team.objects.count(), 0)
-        self.assertEqual(TeamMembership.objects.count(), 0)
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
+        self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
 
 
 @override_settings(
@@ -379,8 +379,8 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
 
         self.backend._sync_teams(user, profile, claims)
 
-        self.assertEqual(Team.objects.count(), 3)
-        team_names = {t.name for t in Team.objects.all()}
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 3)
+        team_names = {t.name for t in Team.objects.filter(org=self.org)}
         self.assertEqual(team_names, {"E123", "E456_Test", "E789.Test"})
 
     def test_very_long_team_names(self):
@@ -408,8 +408,8 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
 
         self.backend._sync_teams(user, profile, claims)
 
-        self.assertEqual(Team.objects.count(), 2)
-        team_names = {t.name for t in Team.objects.all()}
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 2)
+        team_names = {t.name for t in Team.objects.filter(org=self.org)}
         self.assertEqual(team_names, {"E123", "E456"})
 
 
@@ -438,8 +438,8 @@ class OAuthTeamSettingsTestCase(TestCase):
 
         self.backend._sync_teams(user, profile, claims)
 
-        self.assertEqual(Team.objects.count(), 0)
-        self.assertEqual(TeamMembership.objects.count(), 0)
+        self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
+        self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
 
     def test_custom_filter_function(self):
         """Test custom filter function."""
@@ -454,8 +454,8 @@ class OAuthTeamSettingsTestCase(TestCase):
 
             backend._sync_teams(user, profile, claims)
 
-            self.assertEqual(Team.objects.count(), 2)
-            team_names = {t.name for t in Team.objects.all()}
+            self.assertEqual(Team.objects.filter(org=self.org).count(), 2)
+            team_names = {t.name for t in Team.objects.filter(org=self.org)}
             self.assertEqual(team_names, {"E123", "E456"})
 
     def test_enabled_flag_false(self):
@@ -470,8 +470,8 @@ class OAuthTeamSettingsTestCase(TestCase):
 
             backend._sync_teams(user, profile, claims)
 
-            self.assertEqual(Team.objects.count(), 0)
-            self.assertEqual(TeamMembership.objects.count(), 0)
+            self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
+            self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
 
     def test_creation_disabled_flag(self):
         """Test that teams are not created when ENABLE_OAUTH_GROUP_CREATION=False."""
@@ -484,8 +484,8 @@ class OAuthTeamSettingsTestCase(TestCase):
 
             self.backend._sync_teams(user, profile, claims)
 
-            self.assertEqual(Team.objects.count(), 0)
-            self.assertEqual(TeamMembership.objects.count(), 0)
+            self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
+            self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
 
     def test_manual_team_not_affected_by_oauth_sync(self):
         """Test that manually created teams without oauth_group_name are not affected."""

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -8,22 +8,35 @@ from django.test import TestCase, override_settings
 
 from management.auth import OIDCBackend
 from management.models import Org, Team, TeamMembership, UserProfile
-from management.tests.helpers import sample_team_names, team_names_keep_full
+from management.tests.helpers import (
+    extract_teams_keep_full,
+    map_team_names_keep_full,
+    sample_extract_teams,
+    sample_map_team_names,
+)
 
 User = get_user_model()
 
 
-def custom_filter_team_names(claims) -> list[tuple[str, str]]:
+def custom_extract_teams(claims) -> list[str]:
     """
     Custom filter that only allows specific group names.
     """
-    return [("E123", "E123"), ("E456", "E456")]
+    return ["E123", "E456"]
+
+
+def custom_map_team_names(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Map team names keeping them as-is.
+    """
+    return [(name, name) for name in team_names]
 
 
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_extract_teams,
+    OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=sample_map_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -84,7 +97,10 @@ class OAuthTeamCreationTestCase(TestCase):
         user2.groups.add(self.user_group)
         profile2 = UserProfile.objects.create(user=user2, org=self.org)
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_keep_full):
+        with override_settings(
+            OAUTH_TEAM_NAMES_FUNCTION=extract_teams_keep_full,
+            OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_keep_full,
+        ):
             self.backend._sync_teams(user2, profile2, claims)
 
         # Should rename existing team, not create a duplicate
@@ -112,7 +128,10 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_keep_full):
+        with override_settings(
+            OAUTH_TEAM_NAMES_FUNCTION=extract_teams_keep_full,
+            OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_keep_full,
+        ):
             self.backend._sync_teams(user, profile, claims)
 
         # Should NOT rename old_team (name collision with blocker)
@@ -186,7 +205,8 @@ class OAuthTeamCreationTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_extract_teams,
+    OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=sample_map_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -329,7 +349,8 @@ class OAuthTeamMembershipTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_extract_teams,
+    OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=sample_map_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -417,6 +438,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
     OAUTH_TEAM_NAMES_FUNCTION=lambda claims: [],
+    OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=lambda names: [],
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )
@@ -444,7 +466,10 @@ class OAuthTeamSettingsTestCase(TestCase):
     def test_custom_filter_function(self):
         """Test custom filter function."""
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=custom_filter_team_names):
+        with override_settings(
+            OAUTH_TEAM_NAMES_FUNCTION=custom_extract_teams,
+            OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=custom_map_team_names,
+        ):
             backend = OIDCBackend()
             claims = {"email": "test@example.com", "groups": ["E123", "E456", "E789"]}
 
@@ -507,7 +532,8 @@ class OAuthTeamSettingsTestCase(TestCase):
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
-    OAUTH_TEAM_NAMES_FUNCTION=sample_team_names,
+    OAUTH_TEAM_NAMES_FUNCTION=sample_extract_teams,
+    OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=sample_map_team_names,
     OIDC_RP_SIGN_ALGO="HS256",
     OIDC_RP_IDP_SIGN_KEY="test-key",
 )

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -32,6 +32,11 @@ def custom_map_team_names(team_names: list[str]) -> list[tuple[str, str]]:
     return [(name, name) for name in team_names]
 
 
+def sync_teams(backend, user, profile, claims):
+    """Sync teams from claims using the active team-name extraction."""
+    backend._sync_team_membership(user, profile, backend._get_team_names(claims))
+
+
 @override_settings(
     ENABLE_OAUTH_GROUP_MANAGEMENT=True,
     ENABLE_OAUTH_GROUP_CREATION=True,
@@ -59,7 +64,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 2)
         self.assertTrue(Team.objects.filter(name="E123", org=self.org).exists())
@@ -85,7 +90,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user1 = User.objects.create_user(username="user1", email="user1@example.com")
         user1.groups.add(self.user_group)
         profile1 = UserProfile.objects.create(user=user1, org=self.org)
-        self.backend._sync_teams(user1, profile1, claims)
+        sync_teams(self.backend, user1, profile1, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 1)
         team = Team.objects.get(oauth_group_name="E123-Students", org=self.org)
@@ -101,7 +106,8 @@ class OAuthTeamCreationTestCase(TestCase):
             OAUTH_TEAM_NAMES_FUNCTION=extract_teams_keep_full,
             OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_keep_full,
         ):
-            self.backend._sync_teams(user2, profile2, claims)
+            backend = OIDCBackend()
+            sync_teams(backend, user2, profile2, claims)
 
         # Should rename existing team, not create a duplicate
         self.assertEqual(Team.objects.filter(org=self.org).count(), 1)
@@ -132,7 +138,8 @@ class OAuthTeamCreationTestCase(TestCase):
             OAUTH_TEAM_NAMES_FUNCTION=extract_teams_keep_full,
             OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_keep_full,
         ):
-            self.backend._sync_teams(user, profile, claims)
+            backend = OIDCBackend()
+            sync_teams(backend, user, profile, claims)
 
         # Should NOT rename old_team (name collision with blocker)
         old_team.refresh_from_db()
@@ -152,7 +159,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 1)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 1)
@@ -170,7 +177,7 @@ class OAuthTeamCreationTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            backend._sync_teams(user, profile, claims)
+            sync_teams(backend, user, profile, claims)
 
             self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
             self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
@@ -183,7 +190,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
@@ -196,7 +203,7 @@ class OAuthTeamCreationTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
@@ -226,7 +233,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
         self.assertEqual(memberships.count(), 2)
@@ -246,12 +253,12 @@ class OAuthTeamMembershipTestCase(TestCase):
         profile = UserProfile.objects.create(user=user, org=self.org)
 
         initial_groups = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
-        self.backend._sync_teams(user, profile, initial_groups)
+        sync_teams(self.backend, user, profile, initial_groups)
 
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 2)
 
         updated_groups = {"email": "test@example.com", "groups": ["E123-Students"]}
-        self.backend._sync_teams(user, profile, updated_groups)
+        sync_teams(self.backend, user, profile, updated_groups)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
         self.assertEqual(memberships.count(), 1)
@@ -264,7 +271,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         profile = UserProfile.objects.create(user=user, org=self.org)
 
         initial_groups = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
-        self.backend._sync_teams(user, profile, initial_groups)
+        sync_teams(self.backend, user, profile, initial_groups)
 
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 2)
         team1 = Team.objects.get(name="E123", org=self.org)
@@ -273,8 +280,9 @@ class OAuthTeamMembershipTestCase(TestCase):
         self.assertTrue(team2.managed_by_oauth)
 
         with override_settings(ENABLE_OAUTH_GROUP_REMOVAL=False):
+            backend = OIDCBackend()
             updated_groups = {"email": "test@example.com", "groups": ["E123-Students"]}
-            self.backend._sync_teams(user, profile, updated_groups)
+            sync_teams(backend, user, profile, updated_groups)
 
             memberships = TeamMembership.objects.filter(user_profile=profile)
             self.assertEqual(memberships.count(), 1)
@@ -298,7 +306,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 2)
 
         updated_groups = {"email": "test@example.com", "groups": ["E123-Students", "OtherGroup"]}
-        self.backend._sync_teams(user, profile, updated_groups)
+        sync_teams(self.backend, user, profile, updated_groups)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
         team_names = {m.team.name for m in memberships}
@@ -314,12 +322,12 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims_initial)
+        sync_teams(self.backend, user, profile, claims_initial)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 1)
 
         claims_updated = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}
 
-        self.backend._sync_teams(user, profile, claims_updated)
+        sync_teams(self.backend, user, profile, claims_updated)
 
         memberships = TeamMembership.objects.filter(user_profile=profile)
         self.assertEqual(memberships.count(), 2)
@@ -336,7 +344,7 @@ class OAuthTeamMembershipTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         team = Team.objects.filter(name="E123").first()
         self.assertIsNotNone(team)
@@ -375,8 +383,8 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user2.groups.add(self.user_group)
         profile2 = UserProfile.objects.create(user=user2, org=self.other_org)
 
-        self.backend._sync_teams(user1, profile1, claims)
-        self.backend._sync_teams(user2, profile2, claims)
+        sync_teams(self.backend, user1, profile1, claims)
+        sync_teams(self.backend, user2, profile2, claims)
 
         self.assertEqual(Team.objects.filter(name="E123").count(), 2)
 
@@ -398,7 +406,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 3)
         team_names = {t.name for t in Team.objects.filter(org=self.org)}
@@ -414,7 +422,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         team = Team.objects.first()
         self.assertIsNotNone(team)
@@ -427,7 +435,7 @@ class OAuthTeamEdgeCasesTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 2)
         team_names = {t.name for t in Team.objects.filter(org=self.org)}
@@ -458,7 +466,7 @@ class OAuthTeamSettingsTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
@@ -477,7 +485,7 @@ class OAuthTeamSettingsTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            backend._sync_teams(user, profile, claims)
+            sync_teams(backend, user, profile, claims)
 
             self.assertEqual(Team.objects.filter(org=self.org).count(), 2)
             team_names = {t.name for t in Team.objects.filter(org=self.org)}
@@ -493,7 +501,7 @@ class OAuthTeamSettingsTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            backend._sync_teams(user, profile, claims)
+            sync_teams(backend, user, profile, claims)
 
             self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
             self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
@@ -507,7 +515,7 @@ class OAuthTeamSettingsTestCase(TestCase):
             user.groups.add(self.user_group)
             profile = UserProfile.objects.create(user=user, org=self.org)
 
-            self.backend._sync_teams(user, profile, claims)
+            sync_teams(self.backend, user, profile, claims)
 
             self.assertEqual(Team.objects.filter(org=self.org).count(), 0)
             self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 0)
@@ -522,7 +530,7 @@ class OAuthTeamSettingsTestCase(TestCase):
         user.groups.add(self.user_group)
         profile = UserProfile.objects.create(user=user, org=self.org)
 
-        self.backend._sync_teams(user, profile, claims)
+        sync_teams(self.backend, user, profile, claims)
 
         manual_team.refresh_from_db()
         self.assertEqual(manual_team.oauth_group_name, "")
@@ -577,7 +585,7 @@ class OAuthTeamIntegrationTestCase(TestCase):
 
         initial_claims = {"email": "test@example.com", "groups": ["E123-Students"]}
 
-        self.backend._sync_teams(user, profile, initial_claims)
+        sync_teams(self.backend, user, profile, initial_claims)
         self.assertEqual(TeamMembership.objects.filter(user_profile=profile).count(), 1)
 
         updated_claims = {"email": "test@example.com", "groups": ["E123-Students", "E456-Staff"]}

--- a/aqueduct/management/tests/test_oauth_team_creation.py
+++ b/aqueduct/management/tests/test_oauth_team_creation.py
@@ -12,9 +12,7 @@ from management.models import Org, Team, TeamMembership, UserProfile
 User = get_user_model()
 
 
-def sample_team_names(
-    group: str, groups: list[str] | None = None
-) -> tuple[str, str] | None:
+def sample_team_names(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
     """
     Sample implementation that filters groups starting with 'E'
     and extracts team names (removes suffix after dash).

--- a/aqueduct/management/tests/test_oauth_user_role.py
+++ b/aqueduct/management/tests/test_oauth_user_role.py
@@ -1,0 +1,160 @@
+"""Tests for OAuth user role assignment (_update_user_role and role flows)."""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import TestCase, override_settings
+
+from management.auth import OIDCBackend
+from management.models import Org, UserProfile
+from management.tests.helpers import sample_extract_teams, sample_map_team_names
+
+User = get_user_model()
+
+ROLE_SETTINGS = {
+    "ENABLE_OAUTH_GROUP_MANAGEMENT": True,
+    "ENABLE_OAUTH_GROUP_CREATION": True,
+    "OAUTH_TEAM_NAMES_FUNCTION": sample_extract_teams,
+    "OAUTH_DISPLAY_TEAM_NAMES_FUNCTION": sample_map_team_names,
+    "OIDC_RP_SIGN_ALGO": "HS256",
+    "OIDC_RP_IDP_SIGN_KEY": "test-key",
+}
+
+
+@override_settings(**ROLE_SETTINGS)
+class UpdateUserRoleTestCase(TestCase):
+    """Test _update_user_role directly."""
+
+    def setUp(self):
+        self.backend = OIDCBackend()
+        self.org = Org.objects.create(name="test-org")
+
+    def _make_user(self):
+        user = User.objects.create_user(username="testuser", email="test@example.com")
+        profile = UserProfile.objects.create(user=user, org=self.org)
+        return user, profile
+
+    @override_settings(ADMIN_GROUP="E123-Students")
+    def test_admin_when_admin_group_in_team_names(self):
+        user, profile = self._make_user()
+
+        self.backend._update_user_role(user, profile, ["E123-Students", "E456-Staff"])
+
+        profile.refresh_from_db()
+        user.refresh_from_db()
+        self.assertEqual(profile.group, "admin")
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+
+    @override_settings(ADMIN_GROUP="E123-Students")
+    def test_user_when_admin_group_not_in_team_names(self):
+        user, profile = self._make_user()
+
+        self.backend._update_user_role(user, profile, ["E456-Staff"])
+
+        profile.refresh_from_db()
+        user.refresh_from_db()
+        self.assertEqual(profile.group, "user")
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+
+    @override_settings(ADMIN_GROUP="E123-Students")
+    def test_user_when_team_names_empty(self):
+        """An admin is demoted when no team names remain."""
+        user, profile = self._make_user()
+        user.is_staff = True
+        user.is_superuser = True
+        profile.group = "admin"
+        user.save()
+        profile.save()
+
+        self.backend._update_user_role(user, profile, [])
+
+        profile.refresh_from_db()
+        user.refresh_from_db()
+        self.assertEqual(profile.group, "user")
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+
+    @override_settings(ADMIN_GROUP=None)
+    def test_user_when_admin_group_not_configured(self):
+        user, profile = self._make_user()
+
+        self.backend._update_user_role(user, profile, ["E123-Students"])
+
+        profile.refresh_from_db()
+        self.assertEqual(profile.group, "user")
+
+
+@override_settings(**ROLE_SETTINGS)
+class UserRoleIntegrationTestCase(TestCase):
+    """Test role assignment through create_user and update_user."""
+
+    def setUp(self):
+        self.backend = OIDCBackend()
+        self.org = Org.objects.create(name="test-org")
+        self.user_group, _ = Group.objects.get_or_create(name="user")
+
+    @override_settings(ADMIN_GROUP="E123-Students")
+    def test_create_user_assigns_admin_role(self):
+        claims = {"email": "test@example.com", "groups": ["E123-Students"]}
+
+        with patch.object(OIDCBackend, "_org", return_value=self.org):
+            user = User.objects.create_user(username="testuser", email="test@example.com")
+            user.groups.add(self.user_group)
+
+            with patch(
+                "mozilla_django_oidc.auth.OIDCAuthenticationBackend.create_user", return_value=user
+            ):
+                result_user = self.backend.create_user(claims)
+
+            self.assertIsNotNone(result_user)
+            profile = UserProfile.objects.get(user=user)
+            user.refresh_from_db()
+            self.assertEqual(profile.group, "admin")
+            self.assertTrue(user.is_staff)
+            self.assertTrue(user.is_superuser)
+
+    @override_settings(ADMIN_GROUP="E123-Students")
+    def test_create_user_assigns_regular_role_when_not_admin(self):
+        claims = {"email": "test@example.com", "groups": ["E456-Staff"]}
+
+        with patch.object(OIDCBackend, "_org", return_value=self.org):
+            user = User.objects.create_user(username="testuser", email="test@example.com")
+            user.groups.add(self.user_group)
+
+            with patch(
+                "mozilla_django_oidc.auth.OIDCAuthenticationBackend.create_user", return_value=user
+            ):
+                result_user = self.backend.create_user(claims)
+
+            self.assertIsNotNone(result_user)
+            profile = UserProfile.objects.get(user=user)
+            user.refresh_from_db()
+            self.assertEqual(profile.group, "user")
+            self.assertFalse(user.is_staff)
+            self.assertFalse(user.is_superuser)
+
+    @override_settings(ADMIN_GROUP="E123-Students")
+    def test_update_user_demotes_admin_when_admin_group_removed(self):
+        user = User.objects.create_user(username="testuser", email="test@example.com")
+        user.groups.add(self.user_group)
+        user.is_staff = True
+        user.is_superuser = True
+        user.save()
+        profile = UserProfile.objects.create(user=user, org=self.org)
+        profile.group = "admin"
+        profile.save()
+
+        # Admin group removed; only a non-admin team remains
+        updated_claims = {"email": "test@example.com", "groups": ["E456-Staff"]}
+
+        with patch.object(OIDCBackend, "_org", return_value=self.org):
+            self.backend.update_user(user, updated_claims)
+
+        profile.refresh_from_db()
+        user.refresh_from_db()
+        self.assertEqual(profile.group, "user")
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)

--- a/aqueduct/management/tests/test_sync_oauth_team_names_admin.py
+++ b/aqueduct/management/tests/test_sync_oauth_team_names_admin.py
@@ -68,7 +68,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123-Students")
@@ -82,7 +82,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123-Students")
@@ -95,7 +95,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="")
@@ -108,7 +108,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123")
@@ -123,7 +123,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
 
         with (
             patch.object(self.modeladmin, "message_user") as mock_msg,
-            override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_empty),
+            override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_empty),
         ):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
@@ -146,7 +146,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.filter(pk=team1.pk)
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team1.refresh_from_db()
@@ -162,7 +162,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=None):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=None):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123")
@@ -177,7 +177,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         self.assertEqual(Team.objects.get(oauth_group_name="E123-Students").name, "E123")

--- a/aqueduct/management/tests/test_sync_oauth_team_names_admin.py
+++ b/aqueduct/management/tests/test_sync_oauth_team_names_admin.py
@@ -11,7 +11,7 @@ from django.test import RequestFactory, TestCase, override_settings
 
 from management.admin import TeamAdmin, sync_oauth_team_names_action
 from management.models import Org, Team
-from management.tests.helpers import team_names_empty, team_names_strip_suffix
+from management.tests.helpers import map_team_names_empty, map_team_names_strip_suffix
 
 User = get_user_model()
 
@@ -44,7 +44,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123-Students")
@@ -58,7 +58,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123-Students")
@@ -71,7 +71,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="")
@@ -84,7 +84,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123")
@@ -99,7 +99,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
 
         with (
             patch.object(self.modeladmin, "message_user") as mock_msg,
-            override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_empty),
+            override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_empty),
         ):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
@@ -122,7 +122,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.filter(pk=team1.pk)
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team1.refresh_from_db()
@@ -138,7 +138,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=None):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=None):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         team = Team.objects.get(oauth_group_name="E123")
@@ -153,7 +153,7 @@ class SyncOauthTeamNamesAdminActionTestCase(TestCase):
         request = self._create_request()
         queryset = Team.objects.all()
 
-        with override_settings(OAUTH_TEAM_NAMES_FUNCTION=team_names_strip_suffix):
+        with override_settings(OAUTH_DISPLAY_TEAM_NAMES_FUNCTION=map_team_names_strip_suffix):
             sync_oauth_team_names_action(self.modeladmin, request, queryset)
 
         self.assertEqual(Team.objects.get(oauth_group_name="E123-Students").name, "E123")

--- a/aqueduct/management/tests/test_sync_oauth_team_names_admin.py
+++ b/aqueduct/management/tests/test_sync_oauth_team_names_admin.py
@@ -11,33 +11,9 @@ from django.test import RequestFactory, TestCase, override_settings
 
 from management.admin import TeamAdmin, sync_oauth_team_names_action
 from management.models import Org, Team
+from management.tests.helpers import team_names_empty, team_names_strip_suffix
 
 User = get_user_model()
-
-
-def team_names_with_prefix(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-    """
-    Sample function that adds 'Team-' prefix to group names.
-    """
-    if group.startswith("E"):
-        return (f"Team-{group}", group)
-    return None
-
-
-def team_names_strip_suffix(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-    """
-    Sample function that strips suffix after dash.
-    """
-    if group.startswith("E"):
-        return (group.split("-", maxsplit=1)[0], group)
-    return None
-
-
-def team_names_empty(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-    """
-    Sample function that returns None for all groups (causes deletion).
-    """
-    return None
 
 
 @override_settings(

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -444,5 +444,7 @@ LOGGING = {
 
 if TESTING:
     logger = logging.getLogger("aqueduct")
-    logging.disable(logging.NOTSET)
-    logger.setLevel(logging.DEBUG)
+    logging.disable(logging.ERROR)
+    logger.setLevel(logging.CRITICAL)
+    # logging.disable(logging.NOTSET)
+    # logger.setLevel(logging.DEBUG)

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -138,30 +138,47 @@ ENABLE_OAUTH_GROUP_CREATION = os.getenv("ENABLE_OAUTH_GROUP_CREATION", "True").l
 ENABLE_OAUTH_GROUP_REMOVAL = os.getenv("ENABLE_OAUTH_GROUP_REMOVAL", "True").lower() == "true"
 
 
-def default_oauth_team_names(claims) -> list[tuple[str, str]]:
+def default_oauth_team_names(claims: dict[str, Any]) -> list[str]:
     """
-    Default function to transform OAuth claims to team mappings.
+    Default function to extract team names from OAuth claims.
 
     Args:
-        claims: The full OAuth claims dict containing 'groups' and other user info
+        claims: The full OAuth claims dict.
 
     Returns:
-        List of (team_name, original_group_name) tuples, or empty list if none.
+        List of team names, or empty list if none.
 
     Example:
-        def my_transform(claims) -> list[tuple[str, str]]:
-            groups = claims.get('groups', [])
+        def my_extract_team_names(claims) -> list[str]:
+            team_names = claims.get('groups', [])
+            return [team_name for team_name in team_names if team_name.startswith('E')]
+    """
+    return []
+
+
+def default_oauth_display_team_names(team_names: list[str]) -> list[tuple[str, str]]:
+    """
+    Default function to map team names to display team names.
+
+    Args:
+        team_names: List of team names.
+
+    Returns:
+        List of (display_team_name, team_name) tuples, or empty list if none.
+
+    Example:
+        def my_display_team_names(team_names) -> list[tuple[str, str]]:
             result = []
-            for group in groups:
-                if group.startswith('E'):
-                    team_name = group.split('-')[0]
-                    result.append((team_name, group))
+            for team_name in team_names:
+                display_team_name = team_name.split('-')[0]
+                result.append((display_team_name, team_name))
             return result
     """
     return []
 
 
 OAUTH_TEAM_NAMES_FUNCTION = default_oauth_team_names
+OAUTH_DISPLAY_TEAM_NAMES_FUNCTION = default_oauth_display_team_names
 
 EXTRA_NAV_LINKS = {
     "Bug Report": "https://github.com/TU-Wien-dataLAB/aqueduct/issues/new?template=bug_report.md",
@@ -427,7 +444,5 @@ LOGGING = {
 
 if TESTING:
     logger = logging.getLogger("aqueduct")
-    logging.disable(logging.ERROR)
-    logger.setLevel(logging.CRITICAL)
-    # logging.disable(logging.NOTSET)
-    # logger.setLevel(logging.DEBUG)
+    logging.disable(logging.NOTSET)
+    logger.setLevel(logging.DEBUG)

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -444,7 +444,5 @@ LOGGING = {
 
 if TESTING:
     logger = logging.getLogger("aqueduct")
-    logging.disable(logging.ERROR)
-    logger.setLevel(logging.CRITICAL)
-    # logging.disable(logging.NOTSET)
-    # logger.setLevel(logging.DEBUG)
+    logging.disable(logging.NOTSET)
+    logger.setLevel(logging.DEBUG)

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import logging
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -132,35 +131,38 @@ ADMIN_GROUP = "default"  # all users are admins
 # OAuth Group Management Settings
 # Controls automatic team creation and membership management from OAuth groups
 
-ENABLE_OAUTH_GROUP_MANAGEMENT = os.getenv("ENABLE_OAUTH_GROUP_MANAGEMENT", "False").lower() == "true"
+ENABLE_OAUTH_GROUP_MANAGEMENT = (
+    os.getenv("ENABLE_OAUTH_GROUP_MANAGEMENT", "False").lower() == "true"
+)
 ENABLE_OAUTH_GROUP_CREATION = os.getenv("ENABLE_OAUTH_GROUP_CREATION", "True").lower() == "true"
 ENABLE_OAUTH_GROUP_REMOVAL = os.getenv("ENABLE_OAUTH_GROUP_REMOVAL", "True").lower() == "true"
 
 
-def default_oauth_team_names_from_groups(
-    group: str, groups: list[str] | None = None
-) -> tuple[str, str] | None:
+def default_oauth_team_names(claims) -> list[tuple[str, str]]:
     """
-    Default function to transform a single OAuth group name to a team name.
+    Default function to transform OAuth claims to team mappings.
 
     Args:
-        group: The specific OAuth group name to transform
-        groups: Full list of user's groups for context (optional)
+        claims: The full OAuth claims dict containing 'groups' and other user info
 
     Returns:
-        Tuple of (transformed_team_name, original_group_name) or None to skip this group
+        List of tuples: [(transformed_team_name, original_group_name), ...]
+        or empty list to skip team creation
 
     Example:
-        def my_transform(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
-            if group.startswith("E"):
-                team_name = group.split("-")[0]
-                return (team_name, group)
-            return None
+        def my_transform(claims) -> list[tuple[str, str]]:
+            groups = claims.get('groups', [])
+            result = []
+            for group in groups:
+                if group.startswith('E'):
+                    team_name = group.split('-')[0]
+                    result.append((team_name, group))
+            return result
     """
-    return None
+    return []
 
 
-OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION = default_oauth_team_names_from_groups
+OAUTH_TEAM_NAMES_FUNCTION = default_oauth_team_names
 
 EXTRA_NAV_LINKS = {
     "Bug Report": "https://github.com/TU-Wien-dataLAB/aqueduct/issues/new?template=bug_report.md",

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -174,7 +174,7 @@ def default_oauth_display_team_names(team_names: list[str]) -> list[tuple[str, s
                 result.append((display_team_name, team_name))
             return result
     """
-    return []
+    return [(t, t) for t in team_names]
 
 
 OAUTH_TEAM_NAMES_FUNCTION = default_oauth_team_names

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -146,8 +146,7 @@ def default_oauth_team_names(claims) -> list[tuple[str, str]]:
         claims: The full OAuth claims dict containing 'groups' and other user info
 
     Returns:
-        List of tuples: [(transformed_team_name, original_group_name), ...]
-        or empty list to skip team creation
+        List of (team_name, original_group_name) tuples, or empty list if none.
 
     Example:
         def my_transform(claims) -> list[tuple[str, str]]:

--- a/docs/user-guide/admin.md
+++ b/docs/user-guide/admin.md
@@ -42,11 +42,11 @@ OAuth team management automatically syncs user team memberships based on OAuth g
 | `ENABLE_OAUTH_GROUP_MANAGEMENT` | Master switch - when `False`, no team sync happens on login |
 | `ENABLE_OAUTH_GROUP_CREATION` | When `True`, teams are auto-created from OAuth groups; when `False`, users only join existing teams |
 | `ENABLE_OAUTH_GROUP_REMOVAL` | Controls removal from **non-OAuth** teams only. When `True` (default), users are removed from all teams not in their OAuth groups. When `False`, users stay in manually created teams but are **always** removed from OAuth-managed teams when they lose the corresponding OAuth group |
-| `OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION` | Custom logic to transform individual group names |
+| `OAUTH_TEAM_NAMES_FUNCTION` | Custom logic to transform individual group names |
 
 ### Function Signature
 
-The `OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION` should be a callable with this signature:
+The `OAUTH_TEAM_NAMES_FUNCTION` should be a callable with this signature:
 
 ```python
 def transform_group_name(group: str, groups: list[str] | None = None) -> tuple[str, str] | None:
@@ -83,7 +83,7 @@ The function is called once for each OAuth group, allowing you to:
 
 1. User logs in via OAuth
 2. OAuth groups are extracted from claims
-3. For each group, `OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION` is called with the group name and full groups list
+3. For each group, `OAUTH_TEAM_NAMES_FUNCTION` is called with the group name and full groups list
 4. Groups that return a tuple create teams; groups that return `None` are skipped
 5. Teams are created (if `ENABLE_OAUTH_GROUP_CREATION=True`) or reused
 6. User is added to teams via `TeamMembership`
@@ -103,7 +103,7 @@ Rate limits, descriptions, and exclusions remain editable for OAuth-managed team
 
 ### Syncing Team Names
 
-When you change the `OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION` logic, you can update existing team names using the admin action:
+When you change the `OAUTH_TEAM_NAMES_FUNCTION` logic, you can update existing team names using the admin action:
 
 1. Navigate to **Admin → Management → Teams**
 2. Select the teams you want to sync (or select all)
@@ -112,7 +112,7 @@ When you change the `OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION` logic, you can updat
 
 The action will:
 1. Read the stored `oauth_group_name` for each selected OAuth-managed team
-2. Re-apply the current `OAUTH_TEAM_NAMES_FROM_GROUPS_FUNCTION` mapping
+2. Re-apply the current `OAUTH_TEAM_NAMES_FUNCTION` mapping
 3. Update team names based on the mapping result
 4. Skip teams with name collisions or unchanged names
 5. Never affect manually created teams (those with empty `oauth_group_name`)


### PR DESCRIPTION
1. Changed the groups parameter to claims in organization mapping resolution logic.
2. Renamed `_get_teams_from_groups` to `_get_teams` to reflect the updated claims signature.
3. Updated docstrings and comments.
4. Updated existing unit tests and added test cases.