### PR TITLE
152: More efficient http requests processing

### DIFF
--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "gateway.middleware.HTTPResponseMiddleware",
     "management.middleware.HealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",

--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -62,7 +62,6 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "gateway.middleware.HTTPResponseMiddleware",
     "management.middleware.HealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -74,6 +73,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
+    "gateway.middleware.HTTPResponseMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = (

--- a/aqueduct/aqueduct/settings.py
+++ b/aqueduct/aqueduct/settings.py
@@ -73,7 +73,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
-    "gateway.middleware.HTTPResponseMiddleware",
+    "gateway.middleware.HttpResponseMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = (

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -6,7 +6,7 @@ from functools import reduce
 from typing import Any, TypeVar
 
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from litellm.types.utils import ModelResponseStream
 
 from gateway.views.utils import RawJsonResponse, RawStreamingResponse, get_token_usage
@@ -15,6 +15,7 @@ from management.models import Usage
 log = logging.getLogger("aqueduct")
 
 
+ViewResult = HttpResponse | StreamingHttpResponse | RawJsonResponse | RawStreamingResponse
 T = TypeVar("T", bound=ModelResponseStream | dict[str, Any])
 
 
@@ -76,16 +77,15 @@ class HttpResponseMiddleware:
     Transform raw responses from the gateway views into valid HTTPResponses.
 
     This middleware should be applied after all data post-processing
-    middleware.
+    middleware. Note: expects ``get_response`` to be synchronous (views are
+    already wrapped by upstream middleware).
     """
 
-    def __init__(
-        self, get_response: Callable[[ASGIRequest], JsonResponse | StreamingHttpResponse]
-    ) -> None:
+    def __init__(self, get_response: Callable[[ASGIRequest], ViewResult]) -> None:
         self.get_response = get_response
 
-    def __call__(self, request: ASGIRequest) -> JsonResponse | StreamingHttpResponse:
-        """Transform a raw response from a gateway view into a valid HTTPResponse.
+    def __call__(self, request: ASGIRequest) -> JsonResponse | StreamingHttpResponse | HttpResponse:
+        """Transform a raw response from a gateway view into a valid HttpResponse.
 
         If the response is not an instance of ``RawJsonResponse``
         or ``RawStreamingResponse``, it is returned unchanged.

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -1,0 +1,87 @@
+from collections.abc import Callable
+from typing import Any, reveal_type
+
+from asgiref.sync import iscoroutinefunction
+from django.core.handlers.asgi import ASGIRequest
+from django.http import JsonResponse, StreamingHttpResponse
+from django.utils.decorators import sync_only_middleware
+
+from gateway.views.utils import RawJsonResponse, RawStreamingResponse, _openai_stream
+
+
+@sync_only_middleware
+def http_response_middleware(
+    get_response: Callable[[ASGIRequest], JsonResponse | StreamingHttpResponse],
+) -> Callable[[ASGIRequest], Any]:
+    """
+    Transform raw responses from the gateway views into valid HTTPResponses.
+
+    This middleware should be applied after all data post-processing
+    middleware.
+    """
+    if iscoroutinefunction(get_response):
+        # async def middleware(request: ASGIRequest) -> JsonResponse | StreamingHttpResponse:
+        #     response = await get_response(request)
+        #
+        #     if isinstance(response, RawJsonResponse):
+        #         return JsonResponse(response.data, **response.kwargs)
+        #
+        #     if isinstance(response, RawStreamingResponse):
+        #         streaming_content = _openai_stream(response.stream, request_log=response.request_log)
+        #         return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
+        #
+        #
+        #     print(f"\n\nASYNC response: {reveal_type(response)}\n\n")
+        #     return response
+        raise TypeError("Got a coroutine, expected a sync function")
+
+    def middleware(request: ASGIRequest) -> JsonResponse | StreamingHttpResponse:
+        response = get_response(request)
+
+        if isinstance(response, RawJsonResponse):
+            return JsonResponse(response.data, **response.kwargs)
+
+        if isinstance(response, RawStreamingResponse):
+            streaming_content = _openai_stream(response.stream, request_log=response.request_log)
+            return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
+
+        print(f"\n\nSYNC response: {reveal_type(response)}\n\n")
+        return response
+
+    return middleware
+
+
+class HTTPResponseMiddleware:
+    """
+    Transform raw responses from the gateway views into valid HTTPResponses.
+
+    This middleware should be applied after all data post-processing
+    middleware.
+    """
+
+    # sync_capable = False
+    # async_capable = True
+
+    def __init__(
+        self, get_response: Callable[[ASGIRequest], JsonResponse | StreamingHttpResponse]
+    ) -> None:
+        self.get_response = get_response
+        # if iscoroutinefunction(get_response):
+        #     markcoroutinefunction(self)
+
+    def __call__(self, request: ASGIRequest) -> JsonResponse | StreamingHttpResponse:
+        """Transform a raw response from a gateway view into a valid HTTPResponse.
+
+        If the response is not an instance of ``RawJsonResponse``
+        or ``RawStreamingResponse``, it is returned unchanged.
+        """
+        response = self.get_response(request)
+
+        if isinstance(response, RawJsonResponse):
+            return JsonResponse(response.data, **response.kwargs)
+
+        if isinstance(response, RawStreamingResponse):
+            streaming_content = _openai_stream(response.stream, request_log=response.request_log)
+            return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
+
+        return response

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -83,13 +83,13 @@ class HttpResponseMiddleware:
         if isinstance(response, RawJsonResponse):
             # Merge headers from response.headers (may have been modified after init)
             kwargs = response.kwargs.copy()
-            kwargs["headers"] = dict(response.headers)
+            kwargs["headers"].update(response.headers)
             return JsonResponse(response.content, **kwargs)
 
         if isinstance(response, RawStreamingResponse):
             # Merge headers from response.headers (may have been modified after init)
             kwargs = response.kwargs.copy()
-            kwargs["headers"] = dict(response.headers)
+            kwargs["headers"].update(response.headers)
 
             if request.path.startswith("/mcp-servers/"):  # what about is_initialize?
                 # MCP responses need special treatment... but this doesn't work still (TODO!)

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -1,9 +1,45 @@
-from collections.abc import Callable
+import time
+from collections.abc import AsyncGenerator, Callable
+from functools import reduce
 
 from django.core.handlers.asgi import ASGIRequest
 from django.http import JsonResponse, StreamingHttpResponse
 
-from gateway.views.utils import RawJsonResponse, RawStreamingResponse, _openai_stream
+from gateway.views.utils import RawJsonResponse, RawStreamingResponse, get_token_usage
+from management.models import Usage
+
+
+async def _openai_stream(response: RawStreamingResponse) -> AsyncGenerator[str, None]:
+    """Process streaming response with transforms and log token usage."""
+    token_usage = Usage(0, 0)
+    start_time = time.monotonic()
+
+    # TODO: we don't log mcp requests! -> handle this case separately
+
+    async for raw_chunk in response.streaming_content:
+        # Apply all registered transforms
+        chunk = reduce(lambda obj, tr: tr(obj), response.transforms, raw_chunk)
+
+        # Retrieve token usage
+        chunk_usage = get_token_usage(chunk)
+        if chunk_usage.input_tokens > 0 or chunk_usage.output_tokens > 0:
+            token_usage = chunk_usage
+
+        # Format as SSE (suitable for StreamingHttpResponse)
+        chunk_str = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+        try:
+            yield f"data: {chunk_str}\n\n"
+        except Exception as e:
+            yield f"data: {e!s}\n\n"
+
+    end_time = time.monotonic()
+    request_log = response.request_log
+    request_log.token_usage = token_usage
+    request_log.response_time_ms = int((end_time - start_time) * 1000)
+    await request_log.asave()
+
+    # Streaming is done, yield the [DONE] chunk
+    yield "data: [DONE]\n\n"
 
 
 class HttpResponseMiddleware:
@@ -34,9 +70,11 @@ class HttpResponseMiddleware:
             return JsonResponse(response.content, **kwargs)
 
         if isinstance(response, RawStreamingResponse):
-            streaming_content = _openai_stream(
-                response.streaming_content, request_log=response.request_log
-            )
+            # Merge headers from response.headers (may have been modified after init)
+            kwargs = response.kwargs.copy()
+            kwargs["headers"] = dict(response.headers)
+
+            streaming_content = _openai_stream(response)
             return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
 
         return response

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -1,13 +1,14 @@
-import json
 import logging
 import time
 from collections.abc import AsyncGenerator, Callable
 from functools import reduce
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from django.core.handlers.asgi import ASGIRequest
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from litellm.types.utils import ModelResponseStream
+from mcp.types import JSONRPCMessage
+from pydantic import BaseModel
 
 from gateway.views.utils import RawJsonResponse, RawStreamingResponse, get_token_usage
 from management.models import Usage
@@ -16,7 +17,7 @@ log = logging.getLogger("aqueduct")
 
 
 ViewResult = HttpResponse | StreamingHttpResponse | RawJsonResponse | RawStreamingResponse
-T = TypeVar("T", bound=ModelResponseStream | dict[str, Any])
+T = TypeVar("T", bound=ModelResponseStream | JSONRPCMessage)
 
 
 def _apply_transforms(chunk: T, transforms: list[Callable[[T], T]]) -> T:
@@ -68,7 +69,7 @@ async def _mcp_stream(response: RawStreamingResponse) -> AsyncGenerator[str]:
     )
     async for raw_chunk in response.streaming_content:
         chunk = _apply_transforms(raw_chunk, response.transforms)
-        chunk_str = json.dumps(chunk)
+        chunk_str = chunk.model_dump_json(exclude_none=True)
         yield f"data: {chunk_str}\n\n"
 
 
@@ -96,6 +97,22 @@ class HttpResponseMiddleware:
             # Merge headers from response.headers (may have been modified after init)
             kwargs = response.kwargs.copy()
             kwargs["headers"].update(response.headers)
+
+            if isinstance(response.content, BaseModel):
+                response.content = response.content.model_dump(
+                    exclude_none=True, exclude_unset=True, mode="json"
+                )
+            else:
+                for k, v in response.content.items():
+                    if isinstance(v, BaseModel):
+                        # Content can be a dict containing models as values
+                        response.content[k] = v.model_dump()
+                    elif isinstance(v, (list, tuple)) and any(
+                        isinstance(item, BaseModel) for item in v
+                    ):
+                        # Content can be a dict containing a list of models
+                        response.content[k] = [item.model_dump() for item in v]
+
             return JsonResponse(response.content, **kwargs)
 
         if isinstance(response, RawStreamingResponse):

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -3,11 +3,11 @@ import logging
 import time
 from collections.abc import AsyncGenerator, Callable
 from functools import reduce
-from typing import Any
+from typing import Any, TypeVar
 
 from django.core.handlers.asgi import ASGIRequest
 from django.http import JsonResponse, StreamingHttpResponse
-from pydantic import BaseModel
+from litellm.types.utils import ModelResponseStream
 
 from gateway.views.utils import RawJsonResponse, RawStreamingResponse, get_token_usage
 from management.models import Usage
@@ -15,48 +15,60 @@ from management.models import Usage
 log = logging.getLogger("aqueduct")
 
 
-def _dump_to_json(chunk: BaseModel | dict[str, Any]) -> str:
-    """Convert the content chunk to a JSON string (suitable for StreamingHttpResponse)"""
-    if isinstance(chunk, BaseModel):
-        return chunk.model_dump_json(exclude_none=True, exclude_unset=True)
-    if isinstance(chunk, dict):
-        return json.dumps(chunk)
+T = TypeVar("T", bound=ModelResponseStream | dict[str, Any])
 
-    raise TypeError(f"Received unexpected streaming chunk type, {type(chunk)}!")
+
+def _apply_transforms(chunk: T, transforms: list[Callable[[T], T]]) -> T:
+    return reduce(lambda obj, tr: tr(obj), transforms, chunk)
 
 
 async def _openai_stream(response: RawStreamingResponse) -> AsyncGenerator[str, None]:
-    """Process streaming response with transforms and log token usage."""
+    """Post-process streaming response chunks with transforms, and log token usage and request time.
+
+    Note: the last yielded chunk, "data: [DONE]\n\n", is not MCP-compliant. Also,
+    MCP streaming responses do not have `request_log` attached. Use ``_mcp_stream()``
+    for post-processing of MCP streaming responses.
+    """
     token_usage = Usage(0, 0)
     start_time = time.monotonic()
     request_log = response.request_log
+    if request_log is None:
+        raise ValueError(f"Missing request_log for a streaming response: {RawStreamingResponse}!")
 
-    log.debug("Applying the following transforms to each chunk: %s", response.transforms)
+    log.debug(
+        "OpenAI stream. Applying the following transforms to each chunk: %s", response.transforms
+    )
     async for raw_chunk in response.streaming_content:
-        # Apply all registered transforms
-        chunk = reduce(lambda obj, tr: tr(obj), response.transforms, raw_chunk)
+        chunk = _apply_transforms(raw_chunk, response.transforms)
 
-        if request_log is not None:
-            # Retrieve token usage
-            chunk_usage = get_token_usage(chunk)
-            if chunk_usage.input_tokens > 0 or chunk_usage.output_tokens > 0:
-                token_usage = chunk_usage
+        chunk_usage = get_token_usage(chunk)
+        if chunk_usage.input_tokens > 0 or chunk_usage.output_tokens > 0:
+            token_usage = chunk_usage
 
-        chunk_str = _dump_to_json(chunk)
+        chunk_str = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
 
         try:
             yield f"data: {chunk_str}\n\n"
         except Exception as e:
             yield f"data: {e!s}\n\n"
 
-    if request_log is not None:
-        end_time = time.monotonic()
-        request_log.token_usage = token_usage
-        request_log.response_time_ms = int((end_time - start_time) * 1000)
-        await request_log.asave()
+    end_time = time.monotonic()
+    request_log.token_usage = token_usage
+    request_log.response_time_ms = int((end_time - start_time) * 1000)
+    await request_log.asave()
 
-    # Streaming is done, yield the [DONE] chunk
     yield "data: [DONE]\n\n"
+
+
+async def _mcp_stream(response: RawStreamingResponse) -> AsyncGenerator[str]:
+    """MCP-compliant stream, with post-processing transforms applied to each chunk."""
+    log.debug(
+        "MCP stream. Applying the following transforms to each chunk: %s", response.transforms
+    )
+    async for raw_chunk in response.streaming_content:
+        chunk = _apply_transforms(raw_chunk, response.transforms)
+        chunk_str = json.dumps(chunk)
+        yield f"data: {chunk_str}\n\n"
 
 
 class HttpResponseMiddleware:
@@ -91,17 +103,9 @@ class HttpResponseMiddleware:
             kwargs = response.kwargs.copy()
             kwargs["headers"].update(response.headers)
 
-            if request.path.startswith("/mcp-servers/"):  # what about is_initialize?
-                # MCP responses need special treatment... but this doesn't work still (TODO!)
-                async def apply_transforms() -> AsyncGenerator[str]:
-                    async for raw_chunk in response.streaming_content:
-                        chunk = reduce(lambda obj, tr: tr(obj), response.transforms, raw_chunk)
-                        chunk_str = json.dumps(chunk)
-                        yield f"data: {chunk_str}\n\n"
-
-                streaming_content = apply_transforms()
+            if request.path.startswith("/mcp-servers/"):
+                streaming_content = _mcp_stream(response)
             else:
-                # for non-MCP responses
                 streaming_content = _openai_stream(response)
 
             return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -6,7 +6,7 @@ from django.http import JsonResponse, StreamingHttpResponse
 from gateway.views.utils import RawJsonResponse, RawStreamingResponse, _openai_stream
 
 
-class HTTPResponseMiddleware:
+class HttpResponseMiddleware:
     """
     Transform raw responses from the gateway views into valid HTTPResponses.
 

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -1,42 +1,59 @@
+import json
+import logging
 import time
 from collections.abc import AsyncGenerator, Callable
 from functools import reduce
+from typing import Any
 
 from django.core.handlers.asgi import ASGIRequest
 from django.http import JsonResponse, StreamingHttpResponse
+from pydantic import BaseModel
 
 from gateway.views.utils import RawJsonResponse, RawStreamingResponse, get_token_usage
 from management.models import Usage
+
+log = logging.getLogger("aqueduct")
+
+
+def _dump_to_json(chunk: BaseModel | dict[str, Any]) -> str:
+    """Convert the content chunk to a JSON string (suitable for StreamingHttpResponse)"""
+    if isinstance(chunk, BaseModel):
+        return chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+    if isinstance(chunk, dict):
+        return json.dumps(chunk)
+
+    raise TypeError(f"Received unexpected streaming chunk type, {type(chunk)}!")
 
 
 async def _openai_stream(response: RawStreamingResponse) -> AsyncGenerator[str, None]:
     """Process streaming response with transforms and log token usage."""
     token_usage = Usage(0, 0)
     start_time = time.monotonic()
+    request_log = response.request_log
 
-    # TODO: we don't log mcp requests! -> handle this case separately
-
+    log.debug("Applying the following transforms to each chunk: %s", response.transforms)
     async for raw_chunk in response.streaming_content:
         # Apply all registered transforms
         chunk = reduce(lambda obj, tr: tr(obj), response.transforms, raw_chunk)
 
-        # Retrieve token usage
-        chunk_usage = get_token_usage(chunk)
-        if chunk_usage.input_tokens > 0 or chunk_usage.output_tokens > 0:
-            token_usage = chunk_usage
+        if request_log is not None:
+            # Retrieve token usage
+            chunk_usage = get_token_usage(chunk)
+            if chunk_usage.input_tokens > 0 or chunk_usage.output_tokens > 0:
+                token_usage = chunk_usage
 
-        # Format as SSE (suitable for StreamingHttpResponse)
-        chunk_str = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+        chunk_str = _dump_to_json(chunk)
+
         try:
             yield f"data: {chunk_str}\n\n"
         except Exception as e:
             yield f"data: {e!s}\n\n"
 
-    end_time = time.monotonic()
-    request_log = response.request_log
-    request_log.token_usage = token_usage
-    request_log.response_time_ms = int((end_time - start_time) * 1000)
-    await request_log.asave()
+    if request_log is not None:
+        end_time = time.monotonic()
+        request_log.token_usage = token_usage
+        request_log.response_time_ms = int((end_time - start_time) * 1000)
+        await request_log.asave()
 
     # Streaming is done, yield the [DONE] chunk
     yield "data: [DONE]\n\n"
@@ -74,7 +91,19 @@ class HttpResponseMiddleware:
             kwargs = response.kwargs.copy()
             kwargs["headers"] = dict(response.headers)
 
-            streaming_content = _openai_stream(response)
+            if request.path.startswith("/mcp-servers/"):  # what about is_initialize?
+                # MCP responses need special treatment... but this doesn't work still (TODO!)
+                async def apply_transforms() -> AsyncGenerator[str]:
+                    async for raw_chunk in response.streaming_content:
+                        chunk = reduce(lambda obj, tr: tr(obj), response.transforms, raw_chunk)
+                        chunk_str = json.dumps(chunk)
+                        yield f"data: {chunk_str}\n\n"
+
+                streaming_content = apply_transforms()
+            else:
+                # for non-MCP responses
+                streaming_content = _openai_stream(response)
+
             return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
 
         return response

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -28,7 +28,10 @@ class HttpResponseMiddleware:
         response = self.get_response(request)
 
         if isinstance(response, RawJsonResponse):
-            return JsonResponse(response.content, **response.kwargs)
+            # Merge headers from response.headers (may have been modified after init)
+            kwargs = response.kwargs.copy()
+            kwargs["headers"] = dict(response.headers)
+            return JsonResponse(response.content, **kwargs)
 
         if isinstance(response, RawStreamingResponse):
             streaming_content = _openai_stream(

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -28,10 +28,12 @@ class HTTPResponseMiddleware:
         response = self.get_response(request)
 
         if isinstance(response, RawJsonResponse):
-            return JsonResponse(response.data, **response.kwargs)
+            return JsonResponse(response.content, **response.kwargs)
 
         if isinstance(response, RawStreamingResponse):
-            streaming_content = _openai_stream(response.stream, request_log=response.request_log)
+            streaming_content = _openai_stream(
+                response.streaming_content, request_log=response.request_log
+            )
             return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
 
         return response

--- a/aqueduct/gateway/middleware.py
+++ b/aqueduct/gateway/middleware.py
@@ -1,54 +1,9 @@
 from collections.abc import Callable
-from typing import Any, reveal_type
 
-from asgiref.sync import iscoroutinefunction
 from django.core.handlers.asgi import ASGIRequest
 from django.http import JsonResponse, StreamingHttpResponse
-from django.utils.decorators import sync_only_middleware
 
 from gateway.views.utils import RawJsonResponse, RawStreamingResponse, _openai_stream
-
-
-@sync_only_middleware
-def http_response_middleware(
-    get_response: Callable[[ASGIRequest], JsonResponse | StreamingHttpResponse],
-) -> Callable[[ASGIRequest], Any]:
-    """
-    Transform raw responses from the gateway views into valid HTTPResponses.
-
-    This middleware should be applied after all data post-processing
-    middleware.
-    """
-    if iscoroutinefunction(get_response):
-        # async def middleware(request: ASGIRequest) -> JsonResponse | StreamingHttpResponse:
-        #     response = await get_response(request)
-        #
-        #     if isinstance(response, RawJsonResponse):
-        #         return JsonResponse(response.data, **response.kwargs)
-        #
-        #     if isinstance(response, RawStreamingResponse):
-        #         streaming_content = _openai_stream(response.stream, request_log=response.request_log)
-        #         return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
-        #
-        #
-        #     print(f"\n\nASYNC response: {reveal_type(response)}\n\n")
-        #     return response
-        raise TypeError("Got a coroutine, expected a sync function")
-
-    def middleware(request: ASGIRequest) -> JsonResponse | StreamingHttpResponse:
-        response = get_response(request)
-
-        if isinstance(response, RawJsonResponse):
-            return JsonResponse(response.data, **response.kwargs)
-
-        if isinstance(response, RawStreamingResponse):
-            streaming_content = _openai_stream(response.stream, request_log=response.request_log)
-            return StreamingHttpResponse(streaming_content=streaming_content, **response.kwargs)
-
-        print(f"\n\nSYNC response: {reveal_type(response)}\n\n")
-        return response
-
-    return middleware
 
 
 class HTTPResponseMiddleware:
@@ -59,15 +14,10 @@ class HTTPResponseMiddleware:
     middleware.
     """
 
-    # sync_capable = False
-    # async_capable = True
-
     def __init__(
         self, get_response: Callable[[ASGIRequest], JsonResponse | StreamingHttpResponse]
     ) -> None:
         self.get_response = get_response
-        # if iscoroutinefunction(get_response):
-        #     markcoroutinefunction(self)
 
     def __call__(self, request: ASGIRequest) -> JsonResponse | StreamingHttpResponse:
         """Transform a raw response from a gateway view into a valid HTTPResponse.

--- a/aqueduct/gateway/tests/test_endpoints.py
+++ b/aqueduct/gateway/tests/test_endpoints.py
@@ -621,7 +621,7 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
         self.assertEqual(
             req.status_code,
             504,
-            f"Logged streaming timeout request should have status_code=504, got {req.status_code}",
+            f"Logged timeout request should have status_code=504, got {req.status_code}",
         )
         self.assertIn(
             "chat/completions",
@@ -629,27 +629,25 @@ class ChatCompletionsIntegrationTest(ChatCompletionsBase):
             f"Request path should be /chat/completions, got {req.path}",
         )
         self.assertIsNotNone(
-            req.response_time_ms, "Response time should be recorded even for streaming timeout"
+            req.response_time_ms, "Response time should be recorded even for timeout"
         )
         self.assertGreater(
             req.response_time_ms,
             0,
-            f"Response time should be > 0 for streaming timeout, got {req.response_time_ms}",
+            f"Response time should be > 0 for timeout, got {req.response_time_ms}",
         )
         self.assertIsNotNone(
-            req.processing_time_ms, "Processing time should be recorded even for streaming timeout"
+            req.processing_time_ms, "Processing time should be recorded even for timeout"
         )
         self.assertGreater(
             req.processing_time_ms,
             0,
-            f"Processing time should be > 0 for streaming timeout, got {req.processing_time_ms}",
+            f"Processing time should be > 0 for timeout, got {req.processing_time_ms}",
         )
         # Access token_id instead of token to avoid async issues
-        self.assertIsNotNone(req.token_id, "Token should be recorded for streaming timeout")
+        self.assertIsNotNone(req.token_id, "Token should be recorded for timeout")
         self.assertEqual(
-            req.model,
-            self.model,
-            f"Model should be {self.model} for streaming timeout, got {req.model}",
+            req.model, self.model, f"Model should be {self.model} for timeout, got {req.model}"
         )
 
     @override_settings(STREAM_REQUEST_TIMEOUT=5)

--- a/aqueduct/gateway/tests/test_http_response_middleware.py
+++ b/aqueduct/gateway/tests/test_http_response_middleware.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock
 
 from django.contrib.auth import get_user_model
@@ -9,6 +8,8 @@ from django.http import JsonResponse, StreamingHttpResponse
 from django.test import AsyncRequestFactory, override_settings
 from litellm.types.utils import ModelResponseStream
 from litellm.types.utils import Usage as LitellmUsage
+from mcp import JSONRPCResponse
+from mcp.types import JSONRPCMessage
 
 from gateway.middleware import HttpResponseMiddleware
 from gateway.tests.utils.base import GatewayBatchesTestCase
@@ -59,13 +60,11 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
         """RawStreamingResponse for MCP paths should become StreamingHttpResponse."""
 
         async def streaming_content():
-            yield {"result": "mcp-data 1"}
-            yield {"result": "mcp-data 2"}
+            yield JSONRPCResponse(jsonrpc="2.0", id=0, result={"test": "yes"})
+            yield JSONRPCResponse(jsonrpc="2.0", id=0, result={"test": "yes"})
 
-        def transform(chunk: dict[str, Any]):
-            result = chunk["result"]
-            if isinstance(result, str):
-                chunk["result"] = result + " custom suffix"
+        def transform(chunk: JSONRPCMessage):
+            chunk.result["test"] = chunk.result["test"] + " custom suffix"
             return chunk
 
         raw_response = RawStreamingResponse(
@@ -92,7 +91,7 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
             chunk_text = chunk.decode("utf-8")
             self.assertTrue(chunk_text.startswith("data: "))
             content = json.loads(chunk_text.removeprefix("data: "))
-            self.assertTrue(content["result"].endswith(" custom suffix"))
+            self.assertTrue(content["result"]["test"].endswith(" custom suffix"))
 
     def test_passes_through_regular_response(self):
         """Non-raw responses should pass through unchanged."""

--- a/aqueduct/gateway/tests/test_http_response_middleware.py
+++ b/aqueduct/gateway/tests/test_http_response_middleware.py
@@ -1,7 +1,7 @@
 import json
 from http import HTTPStatus
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from asgiref.sync import sync_to_async
 from django.conf import settings
@@ -36,8 +36,8 @@ from gateway.views import (
     vector_stores,
 )
 from gateway.views import response as response_view
-from gateway.views.mcp import mcp_server
-from gateway.views.utils import RawJsonResponse, register_response_in_cache
+from gateway.views.mcp import ManagedMCPSession, mcp_server, session_manager
+from gateway.views.utils import RawJsonResponse, RawStreamingResponse, register_response_in_cache
 from management.models import Batch as BatchModel
 from management.models import (
     BatchStatus,
@@ -109,6 +109,19 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(response, RawJsonResponse)
 
+    async def test_completions_streaming_returns_raw_response(self):
+        url = reverse("gateway:completions")
+        payload = {"model": "gpt-4.1-nano", "prompt": "Hello", "stream": True}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(completions)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawStreamingResponse)
+
     async def test_chat_completions_returns_raw_response(self):
         url = reverse("gateway:chat_completions")
         payload = {
@@ -127,6 +140,26 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_chat_completions_streaming_returns_raw_response(self):
+        url = reverse("gateway:chat_completions")
+        payload = {
+            "model": "gpt-4.1-nano",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"},
+            ],
+            "stream": True,
+        }
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(chat_completions)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawStreamingResponse)
 
     async def test_embeddings_returns_raw_response(self):
         url = reverse("gateway:embeddings")
@@ -156,6 +189,19 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_transcriptions_streaming_returns_raw_response(self):
+        url = reverse("gateway:transcriptions")
+        file = SimpleUploadedFile("test.oga", b"", content_type="audio/ogg")
+        request = self.factory.post(
+            url, data={"file": file, "model": "whisper-1", "stream": "true"}, **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(transcriptions)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawStreamingResponse)
 
     async def test_image_generation_returns_raw_response(self):
         url = reverse("gateway:image_generation")
@@ -289,6 +335,24 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(response, RawJsonResponse)
 
+    async def test_create_response_streaming_returns_raw_response(self):
+        url = reverse("gateway:responses")
+        payload = {
+            "model": "gpt-4.1-nano",
+            "input": [{"role": "user", "content": "Hello"}],
+            "max_output_tokens": 50,
+            "stream": True,
+        }
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(create_response)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawStreamingResponse)
+
     async def test_response_get_delete_returns_raw_response(self):
         response_id = "resp_test123"
         register_response_in_cache(response_id, model=self.model, email="me@example.com")
@@ -347,8 +411,31 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
         response = await middleware(request)
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        # TODO: If I make it RawJsonResponse in the view, other MCP tests fail :<
         self.assertIsInstance(response, RawJsonResponse)
+
+    @override_settings(MCP_ENABLE_DNS_REBINDING_PROTECTION=False)
+    @patch("gateway.views.mcp.get_mcp_config")
+    @patch.object(session_manager, "get_session")
+    async def test_mcp_server_get_returns_raw_response(self, mock_get_session, mock_get_mcp_config):
+        mock_get_mcp_config.return_value = {"test_mcp_server": {"url": self.mock_server.base_url}}
+        session_id = "1868a90c"
+        mock_session = Mock(spec=ManagedMCPSession, session_id=session_id, terminated=False)
+        mock_get_session.return_value = mock_session
+
+        url = reverse("gateway:mcp_server", kwargs={"name": "test_mcp_server"})
+
+        # with patch.object(session_manager, "_sessions", return_value={session_id: mock_session}):
+        request = self.factory.get(
+            url,
+            content_type="application/json",
+            headers={**self.token_header, "Mcp-Session-Id": session_id},
+        )
+
+        middleware = await self._wrap_with_middleware(mcp_server)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawStreamingResponse)
 
     async def test_vector_stores_returns_raw_response(self):
         url = reverse("gateway:vector_stores")

--- a/aqueduct/gateway/tests/test_http_response_middleware.py
+++ b/aqueduct/gateway/tests/test_http_response_middleware.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import HttpResponse, StreamingHttpResponse
 from django.test import AsyncRequestFactory, override_settings
 from django.urls import resolve, reverse
 
@@ -26,6 +27,7 @@ from gateway.views import (
     files,
     get_response_input_items,
     image_generation,
+    speech,
     transcriptions,
     vector_store,
     vector_store_file,
@@ -47,6 +49,7 @@ from management.models import (
     VectorStoreFile,
     VectorStoreStatus,
 )
+from mock_api.mock_configs import MockPlainTextConfig
 
 User = get_user_model()
 
@@ -175,6 +178,24 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(response, RawJsonResponse)
 
+    async def test_speech_returns_streaming_http_response(self):
+        """Speech view returns a regular StreamingHttpResponse, not a raw one."""
+        url = reverse("gateway:speech")
+        payload = {
+            "model": "gpt-4o-mini-tts",
+            "input": "Hello, this is a test of the text-to-speech system.",
+            "voice": "alloy",
+        }
+        request = self.factory.post(
+            url, data=payload, content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(speech)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, StreamingHttpResponse)
+
     async def test_transcriptions_returns_raw_response(self):
         url = reverse("gateway:transcriptions")
         file = SimpleUploadedFile("test.oga", b"", content_type="audio/ogg")
@@ -187,6 +208,25 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_transcriptions_text_format_returns_http_response(self):
+        """Transcriptions view with text-based format returns a regular HttpResponse"""
+        url = reverse("gateway:transcriptions")
+        file = SimpleUploadedFile("test.oga", b"", content_type="audio/ogg")
+        request = self.factory.post(
+            url,
+            data={"file": file, "model": "whisper-1", "response_format": "text"},
+            **self.token_header,
+        )
+
+        transcription = "Hello. This is a mock text transcription.\n"
+        mock_resp = MockPlainTextConfig(response_data=transcription)
+        with self.mock_server.patch_external_api(url, mock_resp):
+            middleware = await self._wrap_with_middleware(transcriptions)
+            response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, HttpResponse)
 
     async def test_transcriptions_streaming_returns_raw_response(self):
         url = reverse("gateway:transcriptions")

--- a/aqueduct/gateway/tests/test_http_response_middleware.py
+++ b/aqueduct/gateway/tests/test_http_response_middleware.py
@@ -1,0 +1,611 @@
+import json
+from http import HTTPStatus
+from pathlib import Path
+from unittest.mock import patch
+
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.middleware import AuthenticationMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import AsyncRequestFactory, override_settings
+from django.urls import resolve, reverse
+
+from gateway.middleware import HttpResponseMiddleware
+from gateway.tests.utils.base import GatewayBatchesTestCase
+from gateway.views import batch as batch_view
+from gateway.views import (
+    batch_cancel,
+    batches,
+    chat_completions,
+    completions,
+    create_response,
+    embeddings,
+    file,
+    files,
+    get_response_input_items,
+    image_generation,
+    transcriptions,
+    vector_store,
+    vector_store_file,
+    vector_store_file_batch,
+    vector_store_file_batches,
+    vector_store_files,
+    vector_store_search,
+    vector_stores,
+)
+from gateway.views import response as response_view
+from gateway.views.mcp import mcp_server
+from gateway.views.utils import RawJsonResponse, register_response_in_cache
+from management.models import Batch as BatchModel
+from management.models import (
+    BatchStatus,
+    FileObject,
+    Token,
+    VectorStore,
+    VectorStoreFile,
+    VectorStoreStatus,
+)
+
+User = get_user_model()
+
+ROOT_DIR = Path(__file__).parent.parent.parent.parent
+
+# TODO: models? and streaming responses
+
+
+@override_settings(
+    OIDC_OP_JWKS_ENDPOINT="https://example.com/application/o/example/jwks/",
+    LITELLM_ROUTER_CONFIG_FILE_PATH=Path(ROOT_DIR / "example_router_config.yaml"),
+    AQUEDUCT_FILES_API_URL="https://files-api.example.com",
+    AQUEDUCT_FILES_API_KEY="test_key",
+)
+class TestHttpResponseMiddleware(GatewayBatchesTestCase):
+    """Test that HttpResponseMiddleware properly transforms raw responses from views."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.factory = AsyncRequestFactory()
+        cls.token_header = {"Authorization": "Bearer sk-123abc"}
+        cls.token = Token.objects.first()
+        cls.user = User.objects.first()
+        cls.vs_obj = VectorStore.objects.create(
+            id="vs-mock-123",
+            token=cls.token,
+            name="Test Store",
+            status=VectorStoreStatus.COMPLETED,
+            usage_bytes=0,
+            created_at=42,
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+        cls.vs_id = cls.vs_obj.id
+
+    async def _wrap_with_middleware(self, view_func):
+        """Wrap a view function with the necessary middleware and HttpResponseMiddleware."""
+
+        async def get_response(request):
+            # Manually populate resolver_match so URL kwargs are available to the view
+            resolver_match = resolve(request.path)
+            request.resolver_match = resolver_match
+            return await view_func(request, *resolver_match.args, **resolver_match.kwargs)
+
+        wrapped = get_response
+        wrapped = HttpResponseMiddleware(wrapped)
+        wrapped = AuthenticationMiddleware(wrapped)
+        return SessionMiddleware(wrapped)
+
+    async def test_completions_returns_raw_response(self):
+        url = reverse("gateway:completions")
+        payload = {"model": "gpt-4.1-nano", "prompt": "Hello"}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(completions)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_chat_completions_returns_raw_response(self):
+        url = reverse("gateway:chat_completions")
+        payload = {
+            "model": "gpt-4.1-nano",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"},
+            ],
+        }
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(chat_completions)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_embeddings_returns_raw_response(self):
+        url = reverse("gateway:embeddings")
+        payload = {
+            "model": "gpt-4.1-nano",
+            "input": ["The quick brown fox jumps over the lazy dog."],
+        }
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(embeddings)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_transcriptions_returns_raw_response(self):
+        url = reverse("gateway:transcriptions")
+        file = SimpleUploadedFile("test.oga", b"", content_type="audio/ogg")
+        request = self.factory.post(
+            url, data={"file": file, "model": "whisper-1"}, **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(transcriptions)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_image_generation_returns_raw_response(self):
+        url = reverse("gateway:image_generation")
+        payload = {"model": "dall-e-2", "prompt": "A beautiful landscape", "size": "256x256"}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(image_generation)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_files_returns_raw_response(self):
+        url = reverse("gateway:files")
+        file = SimpleUploadedFile(
+            "test.jsonl", b'{"custom_id": "bar"}\n', content_type="application/jsonl"
+        )
+        request = self.factory.post(
+            url, data={"file": file, "purpose": "batch"}, **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(files)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_file_get_delete_returns_raw_response(self):
+        url = reverse("gateway:file", kwargs={"file_id": 1})
+        get_request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(file)
+        get_response = await middleware(get_request)
+
+        self.assertIsInstance(get_response, RawJsonResponse)
+
+        delete_request = self.factory.delete(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(file)
+        delete_response = await middleware(delete_request)
+
+        self.assertIsInstance(delete_response, RawJsonResponse)
+
+    async def test_batches_returns_raw_response(self):
+        file_obj = await FileObject.objects.acreate(
+            id="file-remote-123",
+            bytes=1,
+            created_at=42,
+            token=self.token,
+            purpose="batch",
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+        url = reverse("gateway:batches")
+        payload = {
+            "input_file_id": file_obj.id,
+            "completion_window": "24h",
+            "endpoint": reverse("gateway:v1_completions"),
+        }
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(batches)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_batch_get_returns_raw_response(self):
+        # Create a batch to retrieve
+        file_id = await sync_to_async(self._create_jsonl_file)(name="session-auth")
+        token = await Token.objects.aget(pk=1)
+        batch = await BatchModel.objects.acreate(
+            completion_window="24h",
+            created_at=1773058900,
+            endpoint=self.url_chat,
+            id="batch-session-auth",
+            input_file_id=file_id,
+            status=BatchStatus.IN_PROGRESS,
+            token=token,
+        )
+
+        url = reverse("gateway:batch", kwargs={"batch_id": batch.id})
+        request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(batch_view)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_batch_cancel_returns_raw_response(self):
+        # Create a batch to cancel
+        file_id = await sync_to_async(self._create_jsonl_file)(name="session-auth")
+        token = await Token.objects.aget(pk=1)
+        batch = await BatchModel.objects.acreate(
+            completion_window="24h",
+            created_at=1773058900,
+            endpoint=self.url_chat,
+            id="batch-session-auth",
+            input_file_id=file_id,
+            status=BatchStatus.IN_PROGRESS,
+            token=token,
+        )
+
+        url = reverse("gateway:batch_cancel", kwargs={"batch_id": batch.id})
+        request = self.factory.post(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(batch_cancel)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_create_response_returns_raw_response(self):
+        url = reverse("gateway:responses")
+        payload = {
+            "model": "gpt-4.1-nano",
+            "input": [{"role": "user", "content": "Hello"}],
+            "max_output_tokens": 50,
+        }
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(create_response)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_response_get_delete_returns_raw_response(self):
+        response_id = "resp_test123"
+        register_response_in_cache(response_id, model=self.model, email="me@example.com")
+
+        url = reverse("gateway:response", kwargs={"response_id": response_id})
+        request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(response_view)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+        request = self.factory.delete(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(response_view)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_get_response_input_items_returns_raw_response(self):
+        response_id = "resp_test123"
+        register_response_in_cache(response_id, model=self.model, email="me@example.com")
+
+        url = reverse("gateway:response_input_items", kwargs={"response_id": response_id})
+        request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(get_response_input_items)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    @override_settings(MCP_ENABLE_DNS_REBINDING_PROTECTION=False)
+    @patch("gateway.views.mcp.get_mcp_config")
+    async def test_mcp_server_returns_raw_response(self, mock_get_mcp_config):
+        mock_get_mcp_config.return_value = {"test_mcp_server": {"url": self.mock_server.base_url}}
+
+        url = reverse("gateway:mcp_server", kwargs={"name": "test_mcp_server"})
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0"},
+            },
+        }
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(mcp_server)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # TODO: If I make it RawJsonResponse in the view, other MCP tests fail :<
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_stores_returns_raw_response(self):
+        url = reverse("gateway:vector_stores")
+        payload = {"name": "Test Store"}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(vector_stores)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_get_returns_raw_response(self):
+        url = reverse("gateway:vector_store", kwargs={"vector_store_id": self.vs_id})
+        request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(vector_store)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_post_returns_raw_response(self):
+        url = reverse("gateway:vector_store", kwargs={"vector_store_id": self.vs_id})
+        payload = {"name": "Updated Test Store"}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(vector_store)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_delete_returns_raw_response(self):
+        # Create a new vector store which can be deleted
+        vs_obj = await VectorStore.objects.acreate(
+            id="vs-to-delete",
+            token=self.token,
+            name="Test Store",
+            status=VectorStoreStatus.COMPLETED,
+            usage_bytes=0,
+            created_at=42,
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+
+        url = reverse("gateway:vector_store", kwargs={"vector_store_id": vs_obj.id})
+        request = self.factory.delete(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(vector_store)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_search_returns_raw_response(self):
+        url = reverse("gateway:vector_store_search", kwargs={"vector_store_id": self.vs_id})
+        payload = {"query": "test query"}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(vector_store_search)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_files_returns_raw_response(self):
+        file_obj = await FileObject.objects.acreate(
+            id="file-remote-123",
+            bytes=1,
+            created_at=42,
+            token=self.token,
+            purpose="user_data",
+            upstream_url="https://files-api.example.com",
+        )
+
+        url = reverse("gateway:vector_store_files", kwargs={"vector_store_id": self.vs_id})
+        payload = {"file_id": file_obj.id}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(vector_store_files)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_file_get_returns_raw_response(self):
+        file_obj = await FileObject.objects.acreate(
+            id="file-remote-999",
+            bytes=1,
+            created_at=42,
+            token=self.token,
+            purpose="user_data",
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+        vsf = await VectorStoreFile.objects.acreate(
+            id="vsf-mock-42",
+            vector_store=self.vs_obj,
+            file_obj=file_obj,
+            status="in_progress",
+            created_at=9999,
+        )
+        url = reverse(
+            "gateway:vector_store_file", kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id}
+        )
+        request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(vector_store_file)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_file_post_returns_raw_response(self):
+        file_obj = await FileObject.objects.acreate(
+            id="file-remote-999",
+            bytes=1,
+            created_at=42,
+            token=self.token,
+            purpose="user_data",
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+        vsf = await VectorStoreFile.objects.acreate(
+            id="vsf-mock-42",
+            vector_store=self.vs_obj,
+            file_obj=file_obj,
+            status="in_progress",
+            created_at=9999,
+        )
+        url = reverse(
+            "gateway:vector_store_file", kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id}
+        )
+        payload = {"attributes": {"key": "value"}}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(vector_store_file)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_file_delete_returns_raw_response(self):
+        file_obj = await FileObject.objects.acreate(
+            id="file-remote-999",
+            bytes=1,
+            created_at=42,
+            token=self.token,
+            purpose="user_data",
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+        vsf = await VectorStoreFile.objects.acreate(
+            id="vsf-mock-42",
+            vector_store=self.vs_obj,
+            file_obj=file_obj,
+            status="in_progress",
+            created_at=9999,
+        )
+        url = reverse(
+            "gateway:vector_store_file", kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id}
+        )
+        request = self.factory.delete(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(vector_store_file)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_file_content_get_returns_raw_response(self):
+        file_obj = await FileObject.objects.acreate(
+            id="file-remote-999",
+            bytes=1,
+            created_at=42,
+            token=self.token,
+            purpose="user_data",
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+        vsf = await VectorStoreFile.objects.acreate(
+            id="vsf-mock-42",
+            vector_store=self.vs_obj,
+            file_obj=file_obj,
+            status="in_progress",
+            created_at=9999,
+        )
+        url = reverse(
+            "gateway:vector_store_file_content",
+            kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id},
+        )
+        request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(vector_store_file)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_file_batches_returns_raw_response(self):
+        file_obj = await FileObject.objects.acreate(
+            id="file-remote-123",
+            bytes=1,
+            created_at=42,
+            token=self.token,
+            purpose="user_data",
+            upstream_url="https://files-api.example.com",
+        )
+        url = reverse("gateway:vector_store_file_batches", kwargs={"vector_store_id": self.vs_id})
+        payload = {"file_ids": [file_obj.id]}
+        request = self.factory.post(
+            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        )
+
+        middleware = await self._wrap_with_middleware(vector_store_file_batches)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)
+
+    async def test_vector_store_file_batch_get_returns_raw_response(self):
+        # Create a batch first
+        file = await FileObject.objects.acreate(
+            id="file-mock-123",
+            bytes=100,
+            created_at=1234,
+            filename="test.txt",
+            purpose="user_data",
+            token=self.token,
+            upstream_url=settings.AQUEDUCT_FILES_API_URL,
+        )
+        batches_url = reverse(
+            "gateway:vector_store_file_batches", kwargs={"vector_store_id": self.vs_id}
+        )
+        resp = await self.async_client.post(
+            batches_url,
+            data=json.dumps({"file_ids": [file.id]}),
+            headers=self.headers,
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, f"Create batch failed: {resp.json()}")
+        batch_id = resp.json()["id"]
+
+        url = reverse(
+            "gateway:vector_store_file_batch",
+            kwargs={"vector_store_id": self.vs_id, "batch_id": batch_id},
+        )
+        request = self.factory.get(url, **self.token_header)
+
+        middleware = await self._wrap_with_middleware(vector_store_file_batch)
+        response = await middleware(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsInstance(response, RawJsonResponse)

--- a/aqueduct/gateway/tests/test_http_response_middleware.py
+++ b/aqueduct/gateway/tests/test_http_response_middleware.py
@@ -1,55 +1,19 @@
 import json
-from http import HTTPStatus
 from pathlib import Path
-from unittest.mock import Mock, patch
+from typing import Any
+from unittest.mock import AsyncMock
 
-from asgiref.sync import sync_to_async
-from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.middleware import AuthenticationMiddleware
-from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.http import HttpResponse, StreamingHttpResponse
+from django.core.handlers.asgi import ASGIRequest
+from django.http import JsonResponse, StreamingHttpResponse
 from django.test import AsyncRequestFactory, override_settings
-from django.urls import resolve, reverse
+from litellm.types.utils import ModelResponseStream
+from litellm.types.utils import Usage as LitellmUsage
 
 from gateway.middleware import HttpResponseMiddleware
 from gateway.tests.utils.base import GatewayBatchesTestCase
-from gateway.views import batch as batch_view
-from gateway.views import (
-    batch_cancel,
-    batches,
-    chat_completions,
-    completions,
-    create_response,
-    embeddings,
-    file,
-    files,
-    get_response_input_items,
-    image_generation,
-    speech,
-    transcriptions,
-    vector_store,
-    vector_store_file,
-    vector_store_file_batch,
-    vector_store_file_batches,
-    vector_store_files,
-    vector_store_search,
-    vector_stores,
-)
-from gateway.views import response as response_view
-from gateway.views.mcp import ManagedMCPSession, mcp_server, session_manager
-from gateway.views.utils import RawJsonResponse, RawStreamingResponse, register_response_in_cache
-from management.models import Batch as BatchModel
-from management.models import (
-    BatchStatus,
-    FileObject,
-    Token,
-    VectorStore,
-    VectorStoreFile,
-    VectorStoreStatus,
-)
-from mock_api.mock_configs import MockPlainTextConfig
+from gateway.views.utils import RawJsonResponse, RawStreamingResponse
+from management.models import Token, Usage
 
 User = get_user_model()
 
@@ -71,666 +35,128 @@ class TestHttpResponseMiddleware(GatewayBatchesTestCase):
         cls.factory = AsyncRequestFactory()
         cls.token_header = {"Authorization": "Bearer sk-123abc"}
         cls.token = Token.objects.first()
-        cls.user = User.objects.first()
-        cls.vs_obj = VectorStore.objects.create(
-            id="vs-mock-123",
-            token=cls.token,
-            name="Test Store",
-            status=VectorStoreStatus.COMPLETED,
-            usage_bytes=0,
-            created_at=42,
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-        cls.vs_id = cls.vs_obj.id
 
-    async def _wrap_with_middleware(self, view_func):
-        """Wrap a view function with the necessary middleware and HttpResponseMiddleware."""
-
-        async def get_response(request):
-            # Manually populate resolver_match so URL kwargs are available to the view
-            resolver_match = resolve(request.path)
-            request.resolver_match = resolver_match
-            return await view_func(request, *resolver_match.args, **resolver_match.kwargs)
-
-        wrapped = get_response
-        wrapped = HttpResponseMiddleware(wrapped)
-        wrapped = AuthenticationMiddleware(wrapped)
-        return SessionMiddleware(wrapped)
-
-    async def test_completions_returns_raw_response(self):
-        url = reverse("gateway:completions")
-        payload = {"model": "gpt-4.1-nano", "prompt": "Hello"}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+    def test_transforms_raw_json_response(self):
+        """RawJsonResponse should become JsonResponse with merged headers."""
+        raw_response = RawJsonResponse(
+            data={"key": "value"}, headers={"X-Custom": "test"}, status=200
         )
 
-        middleware = await self._wrap_with_middleware(completions)
-        response = await middleware(request)
+        def get_response(req: ASGIRequest):
+            return raw_response
 
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
+        middleware = HttpResponseMiddleware(get_response)
+        request = self.factory.get("/test", **self.token_header)
+        response = middleware(request)
 
-    async def test_completions_streaming_returns_raw_response(self):
-        url = reverse("gateway:completions")
-        payload = {"model": "gpt-4.1-nano", "prompt": "Hello", "stream": True}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
+        self.assertIsInstance(response, JsonResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["X-Custom"], "test")
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertEqual(json.loads(response.content), {"key": "value"})
+
+    async def test_transforms_raw_streaming_response_mcp(self):
+        """RawStreamingResponse for MCP paths should become StreamingHttpResponse."""
+
+        async def streaming_content():
+            yield {"result": "mcp-data 1"}
+            yield {"result": "mcp-data 2"}
+
+        def transform(chunk: dict[str, Any]):
+            result = chunk["result"]
+            if isinstance(result, str):
+                chunk["result"] = result + " custom suffix"
+            return chunk
+
+        raw_response = RawStreamingResponse(
+            streaming_content=streaming_content(),
+            request_log=None,
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+            transforms=[transform],
         )
 
-        middleware = await self._wrap_with_middleware(completions)
-        response = await middleware(request)
+        def get_response(req: ASGIRequest):
+            raw_response.headers["MCP-session-id"] = "mcp-test-id"
+            return raw_response
 
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawStreamingResponse)
+        middleware = HttpResponseMiddleware(get_response)
+        request = self.factory.get("/mcp-servers/test", **self.token_header)
+        response = middleware(request)
 
-    async def test_chat_completions_returns_raw_response(self):
-        url = reverse("gateway:chat_completions")
-        payload = {
-            "model": "gpt-4.1-nano",
-            "messages": [
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": "Hello"},
-            ],
-        }
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(chat_completions)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_chat_completions_streaming_returns_raw_response(self):
-        url = reverse("gateway:chat_completions")
-        payload = {
-            "model": "gpt-4.1-nano",
-            "messages": [
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": "Hello"},
-            ],
-            "stream": True,
-        }
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(chat_completions)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawStreamingResponse)
-
-    async def test_embeddings_returns_raw_response(self):
-        url = reverse("gateway:embeddings")
-        payload = {
-            "model": "gpt-4.1-nano",
-            "input": ["The quick brown fox jumps over the lazy dog."],
-        }
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(embeddings)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_speech_returns_streaming_http_response(self):
-        """Speech view returns a regular StreamingHttpResponse, not a raw one."""
-        url = reverse("gateway:speech")
-        payload = {
-            "model": "gpt-4o-mini-tts",
-            "input": "Hello, this is a test of the text-to-speech system.",
-            "voice": "alloy",
-        }
-        request = self.factory.post(
-            url, data=payload, content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(speech)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(response, StreamingHttpResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/event-stream")
+        self.assertEqual(response["mcp-session-id"], "mcp-test-id")
 
-    async def test_transcriptions_returns_raw_response(self):
-        url = reverse("gateway:transcriptions")
-        file = SimpleUploadedFile("test.oga", b"", content_type="audio/ogg")
-        request = self.factory.post(
-            url, data={"file": file, "model": "whisper-1"}, **self.token_header
+        async for chunk in response.streaming_content:
+            chunk_text = chunk.decode("utf-8")
+            self.assertTrue(chunk_text.startswith("data: "))
+            content = json.loads(chunk_text.removeprefix("data: "))
+            self.assertTrue(content["result"].endswith(" custom suffix"))
+
+    def test_passes_through_regular_response(self):
+        """Non-raw responses should pass through unchanged."""
+        regular_response = JsonResponse({"status": "ok"})
+
+        def get_response(req: ASGIRequest):
+            return regular_response
+
+        middleware = HttpResponseMiddleware(get_response)
+        request = self.factory.get("/test")
+        response = middleware(request)
+
+        self.assertIs(response, regular_response)
+
+    async def test_openai_stream_logs_token_usage(self):
+        """OpenAI streaming should update request_log and apply transforms."""
+
+        async def streaming_content():
+            yield ModelResponseStream(
+                id="chatcmpl-stream-reasoning",
+                created=1768398242,
+                model="gpt-4.1-nano",
+                object="chat.completion.chunk",
+                stream=True,
+                stream_options={"include_usage": True},
+                choices=[{"index": 0, "delta": {"role": "assistant"}}],
+                usage=LitellmUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            )
+
+        def add_reasoning(chunk: ModelResponseStream) -> ModelResponseStream:
+            choices = chunk.get("choices", [])
+            for choice in choices:
+                message = choice.get("delta")
+                if message:
+                    message["reasoning"] = "Deep chain of thought..."
+            return chunk
+
+        mock_request_log = AsyncMock(id=1, token_usage=None, response_time_ms=None)
+        mock_request_log.asave = AsyncMock()
+
+        raw_response = RawStreamingResponse(
+            streaming_content=streaming_content(),
+            request_log=mock_request_log,
+            transforms=[add_reasoning],
         )
 
-        middleware = await self._wrap_with_middleware(transcriptions)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_transcriptions_text_format_returns_http_response(self):
-        """Transcriptions view with text-based format returns a regular HttpResponse"""
-        url = reverse("gateway:transcriptions")
-        file = SimpleUploadedFile("test.oga", b"", content_type="audio/ogg")
-        request = self.factory.post(
-            url,
-            data={"file": file, "model": "whisper-1", "response_format": "text"},
-            **self.token_header,
-        )
-
-        transcription = "Hello. This is a mock text transcription.\n"
-        mock_resp = MockPlainTextConfig(response_data=transcription)
-        with self.mock_server.patch_external_api(url, mock_resp):
-            middleware = await self._wrap_with_middleware(transcriptions)
-            response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, HttpResponse)
-
-    async def test_transcriptions_streaming_returns_raw_response(self):
-        url = reverse("gateway:transcriptions")
-        file = SimpleUploadedFile("test.oga", b"", content_type="audio/ogg")
-        request = self.factory.post(
-            url, data={"file": file, "model": "whisper-1", "stream": "true"}, **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(transcriptions)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawStreamingResponse)
-
-    async def test_image_generation_returns_raw_response(self):
-        url = reverse("gateway:image_generation")
-        payload = {"model": "dall-e-2", "prompt": "A beautiful landscape", "size": "256x256"}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(image_generation)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_files_returns_raw_response(self):
-        url = reverse("gateway:files")
-        file = SimpleUploadedFile(
-            "test.jsonl", b'{"custom_id": "bar"}\n', content_type="application/jsonl"
-        )
-        request = self.factory.post(
-            url, data={"file": file, "purpose": "batch"}, **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(files)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_file_get_delete_returns_raw_response(self):
-        url = reverse("gateway:file", kwargs={"file_id": 1})
-        get_request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(file)
-        get_response = await middleware(get_request)
-
-        self.assertIsInstance(get_response, RawJsonResponse)
-
-        delete_request = self.factory.delete(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(file)
-        delete_response = await middleware(delete_request)
-
-        self.assertIsInstance(delete_response, RawJsonResponse)
-
-    async def test_batches_returns_raw_response(self):
-        file_obj = await FileObject.objects.acreate(
-            id="file-remote-123",
-            bytes=1,
-            created_at=42,
-            token=self.token,
-            purpose="batch",
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-        url = reverse("gateway:batches")
-        payload = {
-            "input_file_id": file_obj.id,
-            "completion_window": "24h",
-            "endpoint": reverse("gateway:v1_completions"),
-        }
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(batches)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_batch_get_returns_raw_response(self):
-        # Create a batch to retrieve
-        file_id = await sync_to_async(self._create_jsonl_file)(name="session-auth")
-        token = await Token.objects.aget(pk=1)
-        batch = await BatchModel.objects.acreate(
-            completion_window="24h",
-            created_at=1773058900,
-            endpoint=self.url_chat,
-            id="batch-session-auth",
-            input_file_id=file_id,
-            status=BatchStatus.IN_PROGRESS,
-            token=token,
-        )
-
-        url = reverse("gateway:batch", kwargs={"batch_id": batch.id})
-        request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(batch_view)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_batch_cancel_returns_raw_response(self):
-        # Create a batch to cancel
-        file_id = await sync_to_async(self._create_jsonl_file)(name="session-auth")
-        token = await Token.objects.aget(pk=1)
-        batch = await BatchModel.objects.acreate(
-            completion_window="24h",
-            created_at=1773058900,
-            endpoint=self.url_chat,
-            id="batch-session-auth",
-            input_file_id=file_id,
-            status=BatchStatus.IN_PROGRESS,
-            token=token,
-        )
-
-        url = reverse("gateway:batch_cancel", kwargs={"batch_id": batch.id})
-        request = self.factory.post(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(batch_cancel)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_create_response_returns_raw_response(self):
-        url = reverse("gateway:responses")
-        payload = {
-            "model": "gpt-4.1-nano",
-            "input": [{"role": "user", "content": "Hello"}],
-            "max_output_tokens": 50,
-        }
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(create_response)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_create_response_streaming_returns_raw_response(self):
-        url = reverse("gateway:responses")
-        payload = {
-            "model": "gpt-4.1-nano",
-            "input": [{"role": "user", "content": "Hello"}],
-            "max_output_tokens": 50,
-            "stream": True,
-        }
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(create_response)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawStreamingResponse)
-
-    async def test_response_get_delete_returns_raw_response(self):
-        response_id = "resp_test123"
-        register_response_in_cache(response_id, model=self.model, email="me@example.com")
-
-        url = reverse("gateway:response", kwargs={"response_id": response_id})
-        request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(response_view)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-        request = self.factory.delete(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(response_view)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_get_response_input_items_returns_raw_response(self):
-        response_id = "resp_test123"
-        register_response_in_cache(response_id, model=self.model, email="me@example.com")
-
-        url = reverse("gateway:response_input_items", kwargs={"response_id": response_id})
-        request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(get_response_input_items)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    @override_settings(MCP_ENABLE_DNS_REBINDING_PROTECTION=False)
-    @patch("gateway.views.mcp.get_mcp_config")
-    async def test_mcp_server_returns_raw_response(self, mock_get_mcp_config):
-        mock_get_mcp_config.return_value = {"test_mcp_server": {"url": self.mock_server.base_url}}
-
-        url = reverse("gateway:mcp_server", kwargs={"name": "test_mcp_server"})
-        payload = {
-            "jsonrpc": "2.0",
-            "id": 0,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2025-06-18",
-                "capabilities": {},
-                "clientInfo": {"name": "test", "version": "1.0"},
-            },
-        }
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(mcp_server)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    @override_settings(MCP_ENABLE_DNS_REBINDING_PROTECTION=False)
-    @patch("gateway.views.mcp.get_mcp_config")
-    @patch.object(session_manager, "get_session")
-    async def test_mcp_server_get_returns_raw_response(self, mock_get_session, mock_get_mcp_config):
-        mock_get_mcp_config.return_value = {"test_mcp_server": {"url": self.mock_server.base_url}}
-        session_id = "1868a90c"
-        mock_session = Mock(spec=ManagedMCPSession, session_id=session_id, terminated=False)
-        mock_get_session.return_value = mock_session
-
-        url = reverse("gateway:mcp_server", kwargs={"name": "test_mcp_server"})
-
-        # with patch.object(session_manager, "_sessions", return_value={session_id: mock_session}):
-        request = self.factory.get(
-            url,
-            content_type="application/json",
-            headers={**self.token_header, "Mcp-Session-Id": session_id},
-        )
-
-        middleware = await self._wrap_with_middleware(mcp_server)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawStreamingResponse)
-
-    async def test_vector_stores_returns_raw_response(self):
-        url = reverse("gateway:vector_stores")
-        payload = {"name": "Test Store"}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(vector_stores)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_get_returns_raw_response(self):
-        url = reverse("gateway:vector_store", kwargs={"vector_store_id": self.vs_id})
-        request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(vector_store)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_post_returns_raw_response(self):
-        url = reverse("gateway:vector_store", kwargs={"vector_store_id": self.vs_id})
-        payload = {"name": "Updated Test Store"}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(vector_store)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_delete_returns_raw_response(self):
-        # Create a new vector store which can be deleted
-        vs_obj = await VectorStore.objects.acreate(
-            id="vs-to-delete",
-            token=self.token,
-            name="Test Store",
-            status=VectorStoreStatus.COMPLETED,
-            usage_bytes=0,
-            created_at=42,
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-
-        url = reverse("gateway:vector_store", kwargs={"vector_store_id": vs_obj.id})
-        request = self.factory.delete(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(vector_store)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_search_returns_raw_response(self):
-        url = reverse("gateway:vector_store_search", kwargs={"vector_store_id": self.vs_id})
-        payload = {"query": "test query"}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(vector_store_search)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_files_returns_raw_response(self):
-        file_obj = await FileObject.objects.acreate(
-            id="file-remote-123",
-            bytes=1,
-            created_at=42,
-            token=self.token,
-            purpose="user_data",
-            upstream_url="https://files-api.example.com",
-        )
-
-        url = reverse("gateway:vector_store_files", kwargs={"vector_store_id": self.vs_id})
-        payload = {"file_id": file_obj.id}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(vector_store_files)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_file_get_returns_raw_response(self):
-        file_obj = await FileObject.objects.acreate(
-            id="file-remote-999",
-            bytes=1,
-            created_at=42,
-            token=self.token,
-            purpose="user_data",
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-        vsf = await VectorStoreFile.objects.acreate(
-            id="vsf-mock-42",
-            vector_store=self.vs_obj,
-            file_obj=file_obj,
-            status="in_progress",
-            created_at=9999,
-        )
-        url = reverse(
-            "gateway:vector_store_file", kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id}
-        )
-        request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(vector_store_file)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_file_post_returns_raw_response(self):
-        file_obj = await FileObject.objects.acreate(
-            id="file-remote-999",
-            bytes=1,
-            created_at=42,
-            token=self.token,
-            purpose="user_data",
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-        vsf = await VectorStoreFile.objects.acreate(
-            id="vsf-mock-42",
-            vector_store=self.vs_obj,
-            file_obj=file_obj,
-            status="in_progress",
-            created_at=9999,
-        )
-        url = reverse(
-            "gateway:vector_store_file", kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id}
-        )
-        payload = {"attributes": {"key": "value"}}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(vector_store_file)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_file_delete_returns_raw_response(self):
-        file_obj = await FileObject.objects.acreate(
-            id="file-remote-999",
-            bytes=1,
-            created_at=42,
-            token=self.token,
-            purpose="user_data",
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-        vsf = await VectorStoreFile.objects.acreate(
-            id="vsf-mock-42",
-            vector_store=self.vs_obj,
-            file_obj=file_obj,
-            status="in_progress",
-            created_at=9999,
-        )
-        url = reverse(
-            "gateway:vector_store_file", kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id}
-        )
-        request = self.factory.delete(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(vector_store_file)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_file_content_get_returns_raw_response(self):
-        file_obj = await FileObject.objects.acreate(
-            id="file-remote-999",
-            bytes=1,
-            created_at=42,
-            token=self.token,
-            purpose="user_data",
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-        vsf = await VectorStoreFile.objects.acreate(
-            id="vsf-mock-42",
-            vector_store=self.vs_obj,
-            file_obj=file_obj,
-            status="in_progress",
-            created_at=9999,
-        )
-        url = reverse(
-            "gateway:vector_store_file_content",
-            kwargs={"vector_store_id": self.vs_id, "file_id": vsf.id},
-        )
-        request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(vector_store_file)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_file_batches_returns_raw_response(self):
-        file_obj = await FileObject.objects.acreate(
-            id="file-remote-123",
-            bytes=1,
-            created_at=42,
-            token=self.token,
-            purpose="user_data",
-            upstream_url="https://files-api.example.com",
-        )
-        url = reverse("gateway:vector_store_file_batches", kwargs={"vector_store_id": self.vs_id})
-        payload = {"file_ids": [file_obj.id]}
-        request = self.factory.post(
-            url, data=json.dumps(payload), content_type="application/json", **self.token_header
-        )
-
-        middleware = await self._wrap_with_middleware(vector_store_file_batches)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
-
-    async def test_vector_store_file_batch_get_returns_raw_response(self):
-        # Create a batch first
-        file = await FileObject.objects.acreate(
-            id="file-mock-123",
-            bytes=100,
-            created_at=1234,
-            filename="test.txt",
-            purpose="user_data",
-            token=self.token,
-            upstream_url=settings.AQUEDUCT_FILES_API_URL,
-        )
-        batches_url = reverse(
-            "gateway:vector_store_file_batches", kwargs={"vector_store_id": self.vs_id}
-        )
-        resp = await self.async_client.post(
-            batches_url,
-            data=json.dumps({"file_ids": [file.id]}),
-            headers=self.headers,
-            content_type="application/json",
-        )
-        self.assertEqual(resp.status_code, 200, f"Create batch failed: {resp.json()}")
-        batch_id = resp.json()["id"]
-
-        url = reverse(
-            "gateway:vector_store_file_batch",
-            kwargs={"vector_store_id": self.vs_id, "batch_id": batch_id},
-        )
-        request = self.factory.get(url, **self.token_header)
-
-        middleware = await self._wrap_with_middleware(vector_store_file_batch)
-        response = await middleware(request)
-
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIsInstance(response, RawJsonResponse)
+        def get_response(req: ASGIRequest):
+            return raw_response
+
+        middleware = HttpResponseMiddleware(get_response)
+        request = self.factory.post("/v1/chat/completions", **self.token_header)
+        response = middleware(request)
+
+        async for chunk in response.streaming_content:
+            chunk_text = chunk.decode("utf-8")
+            self.assertTrue(chunk_text.startswith("data: "))
+            if chunk_text != "data: [DONE]\n\n":
+                content = json.loads(chunk_text.removeprefix("data: "))
+                choices = content["choices"]
+                for choice in choices:
+                    self.assertEqual(choice["delta"]["reasoning"], "Deep chain of thought...")
+
+        # The last "DONE" chunk should be added to an openai stream:
+        self.assertEqual(chunk_text, "data: [DONE]\n\n")
+        mock_request_log.asave.assert_called_once()
+        self.assertEqual(mock_request_log.token_usage, Usage(input_tokens=10, output_tokens=5))
+        self.assertIsNotNone(mock_request_log.response_time_ms)

--- a/aqueduct/gateway/tests/test_http_response_middleware.py
+++ b/aqueduct/gateway/tests/test_http_response_middleware.py
@@ -52,8 +52,6 @@ User = get_user_model()
 
 ROOT_DIR = Path(__file__).parent.parent.parent.parent
 
-# TODO: models? and streaming responses
-
 
 @override_settings(
     OIDC_OP_JWKS_ENDPOINT="https://example.com/application/o/example/jwks/",

--- a/aqueduct/gateway/tests/test_responses.py
+++ b/aqueduct/gateway/tests/test_responses.py
@@ -4,14 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from django.core.cache import caches
-from django.http import JsonResponse
 from django.test import override_settings
 from django.urls import reverse
 
 from gateway.tests.utils import _build_chat_headers, _read_streaming_response_lines
 from gateway.tests.utils.base import GatewayIntegrationTestCase
 from gateway.views.decorators import check_tool_availability
-from gateway.views.utils import register_response_in_cache
+from gateway.views.utils import RawJsonResponse, register_response_in_cache
 from management.models import Request, Token
 
 User = get_user_model()
@@ -369,7 +368,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         """
         # Mock the decorated view function
         mock_view_func = AsyncMock()
-        mock_view_func.return_value = JsonResponse({"result": "success"})
+        mock_view_func.return_value = RawJsonResponse({"result": "success"})
 
         # Create a mock request and token
         request = AsyncMock()
@@ -399,7 +398,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         Should successfully call the decorated function with server_url added.
         """
         mock_view_func = AsyncMock()
-        mock_view_func.return_value = JsonResponse({"result": "success"})
+        mock_view_func.return_value = RawJsonResponse({"result": "success"})
 
         # Mock MCP config
         mock_get_mcp_config.return_value = {"test_mcp_server": {"url": "http://mcp-server:8080"}}
@@ -541,7 +540,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         Should successfully match by URL and rewrite to internal URL.
         """
         mock_view_func = AsyncMock()
-        mock_view_func.return_value = JsonResponse({"result": "success"})
+        mock_view_func.return_value = RawJsonResponse({"result": "success"})
 
         mock_get_mcp_config.return_value = {
             "brave": {"url": "http://mcp-server:8080"},
@@ -606,7 +605,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         Should successfully call the decorated function.
         """
         mock_view_func = AsyncMock()
-        mock_view_func.return_value = JsonResponse({"result": "success"})
+        mock_view_func.return_value = RawJsonResponse({"result": "success"})
 
         request = AsyncMock()
         response_id = "test_response_id"
@@ -633,7 +632,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         Should resolve vector store IDs to remote IDs.
         """
         mock_view_func = AsyncMock()
-        mock_view_func.return_value = JsonResponse({"result": "success"})
+        mock_view_func.return_value = RawJsonResponse({"result": "success"})
 
         request = AsyncMock()
         response_id = "test_response_id"
@@ -669,7 +668,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         Should resolve vector store IDs to remote IDs using team filter.
         """
         mock_view_func = AsyncMock()
-        mock_view_func.return_value = JsonResponse({"result": "success"})
+        mock_view_func.return_value = RawJsonResponse({"result": "success"})
 
         request = AsyncMock()
         response_id = "test_response_id"
@@ -739,7 +738,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         Should pass through without error.
         """
         mock_view_func = AsyncMock()
-        mock_view_func.return_value = JsonResponse({"result": "success"})
+        mock_view_func.return_value = RawJsonResponse({"result": "success"})
 
         request = AsyncMock()
         response_id = "test_response_id"

--- a/aqueduct/gateway/tests/test_responses.py
+++ b/aqueduct/gateway/tests/test_responses.py
@@ -450,8 +450,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         # Should return 400 error without calling the view function
         mock_view_func.assert_not_called()
         self.assertEqual(result.status_code, 400)
-        data = json.loads(result.content)
-        self.assertEqual(data["error"]["message"], "Invalid request")
+        self.assertEqual(result.content["error"]["message"], "Invalid request")
 
     async def test_check_tool_availability_missing_pydantic_model(self):
         """
@@ -474,8 +473,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         # Should return 400 error without calling the view function
         mock_view_func.assert_not_called()
         self.assertEqual(result.status_code, 400)
-        data = json.loads(result.content)
-        self.assertEqual(data["error"]["message"], "Invalid request")
+        self.assertEqual(result.content["error"]["message"], "Invalid request")
 
     @patch("gateway.views.decorators.get_mcp_config")
     async def test_check_tool_availability_mcp_server_excluded(self, mock_get_mcp_config):
@@ -504,8 +502,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         # Should return 404 error without calling the view function
         mock_view_func.assert_not_called()
         self.assertEqual(result.status_code, 404)
-        data = json.loads(result.content)
-        self.assertIn("MCP server not found", data["error"]["message"])
+        self.assertIn("MCP server not found", result.content["error"]["message"])
 
     @patch("gateway.views.decorators.get_mcp_config")
     async def test_check_tool_availability_mcp_server_not_found(self, mock_get_mcp_config):
@@ -535,8 +532,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         # Should return 404 error without calling the view function
         mock_view_func.assert_not_called()
         self.assertEqual(result.status_code, 404)
-        data = json.loads(result.content)
-        self.assertIn("MCP server not found", data["error"]["message"])
+        self.assertIn("MCP server not found", result.content["error"]["message"])
 
     @patch("gateway.views.decorators.get_mcp_config")
     async def test_check_tool_availability_mcp_server_url_match(self, mock_get_mcp_config):
@@ -601,8 +597,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
         # Should return 400 error without calling the view function
         mock_view_func.assert_not_called()
         self.assertEqual(result.status_code, 400)
-        data = json.loads(result.content)
-        self.assertEqual(data["error"]["message"], "Invalid tool type: invalid_tool_type")
+        self.assertEqual(result.content["error"]["message"], "Invalid tool type: invalid_tool_type")
 
     @override_settings(RESPONSES_API_ALLOWED_NATIVE_TOOLS=["allowed_native_tool"])
     async def test_check_tool_availability_allowed_native_tool(self):
@@ -736,8 +731,7 @@ class CheckToolAvailabilityTest(GatewayIntegrationTestCase):
 
         self.assertEqual(result.status_code, 404)
         mock_view_func.assert_not_called()
-        data = json.loads(result.content)
-        self.assertIn("One or more vector stores not found", data["error"]["message"])
+        self.assertIn("One or more vector stores not found", result.content["error"]["message"])
 
     async def test_check_tool_availability_file_search_empty_ids(self):
         """

--- a/aqueduct/gateway/tests/test_vector_stores_api.py
+++ b/aqueduct/gateway/tests/test_vector_stores_api.py
@@ -761,7 +761,6 @@ class TestVectorStoreFileBatches(TestVectorStoresBase):
         data = resp.json()
         self.assertEqual(data["id"], batch_id)
         self.assertEqual(data["file_counts"]["total"], 2)
-        # TODO: more assertions about the objects in the db
 
         # Cancel batch
         cancel_url = reverse(

--- a/aqueduct/gateway/tests/utils/base.py
+++ b/aqueduct/gateway/tests/utils/base.py
@@ -2,7 +2,7 @@ import json
 import os
 from pathlib import Path
 from typing import ClassVar, Literal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -10,15 +10,6 @@ from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from litellm import Router
-from litellm.types.llms.openai import HttpxBinaryResponseContent
-from litellm.types.router import Deployment
-from litellm.types.utils import (
-    EmbeddingResponse,
-    ImageResponse,
-    ModelResponse,
-    TextCompletionResponse,
-)
 from tos.models import TermsOfService, UserAgreement
 
 from gateway.tests.utils import _build_chat_headers, _build_chat_payload
@@ -39,19 +30,6 @@ with ROUTER_CONFIG_PATH.open() as f:
     ROUTER_CONFIG = f.read()
 
 User = get_user_model()
-
-
-def get_mock_router(model: str = "test-model"):
-    router = MagicMock(spec=Router)
-    router.acompletion = AsyncMock(return_value=ModelResponse())
-    router.atext_completion = AsyncMock(return_value=TextCompletionResponse())
-    router.aembedding = AsyncMock(return_value=EmbeddingResponse())
-    router.image_generation = MagicMock(return_value=ImageResponse())
-    router.aspeech = AsyncMock(return_value=HttpxBinaryResponseContent(response=MagicMock()))
-    router.get_deployment = MagicMock(
-        return_value=Deployment("test-model", {"model": f"openai/{model}"})
-    )
-    return router
 
 
 @override_settings(

--- a/aqueduct/gateway/tests/utils/mcp.py
+++ b/aqueduct/gateway/tests/utils/mcp.py
@@ -177,6 +177,7 @@ class MCPLiveServerTestCase(ChannelsLiveServerTestCase):
             cls.mcp_server_process = subprocess.Popen(
                 [
                     "npx",
+                    "--prefer-offline",  # only download when missing => tests can run offline
                     "-y",
                     "@modelcontextprotocol/server-everything@2025.11.25",
                     "streamableHttp",

--- a/aqueduct/gateway/urls.py
+++ b/aqueduct/gateway/urls.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="arg-type"
 from django.urls import path
 from django.views.generic import RedirectView
 

--- a/aqueduct/gateway/views/batches.py
+++ b/aqueduct/gateway/views/batches.py
@@ -48,8 +48,7 @@ async def batches(
             batch_qs = Batch.objects.filter(token__user=token.user)
 
         batch_objects = [
-            b.model.model_dump()
-            async for b in batch_qs.order_by("-created_at").select_related("input_file")
+            b.model async for b in batch_qs.order_by("-created_at").select_related("input_file")
         ]
 
         return RawJsonResponse(
@@ -124,11 +123,8 @@ async def batches(
     )
     await batch_obj.asave()
 
-    # Return upstream response directly (IDs already match)
-    response_data = remote_batch.model_dump()
-    response_data["input_file_id"] = file_obj.id
-
-    return RawJsonResponse(response_data, status=200)
+    remote_batch.input_file_id = file_obj.id
+    return RawJsonResponse(remote_batch, status=200)
 
 
 @csrf_exempt
@@ -179,15 +175,14 @@ async def batch(
         remote_batch.error_file_id, token, client, batch_obj, "error_file"
     )
 
-    # Build response from upstream data, ensuring file IDs match our local records
-    response_data = remote_batch.model_dump()
-    response_data["input_file_id"] = batch_obj.input_file_id
+    # Ensure file IDs in the response data match our local records
+    remote_batch.input_file_id = batch_obj.input_file_id
     if output_file_obj:
-        response_data["output_file_id"] = output_file_obj.id
+        remote_batch.output_file_id = output_file_obj.id
     if error_file_obj:
-        response_data["error_file_id"] = error_file_obj.id
+        remote_batch.error_file_id = error_file_obj.id
 
-    return RawJsonResponse(response_data, status=200)
+    return RawJsonResponse(remote_batch, status=200)
 
 
 @csrf_exempt
@@ -232,8 +227,7 @@ async def batch_cancel(
         batch_obj.cancelled_at = remote_batch.cancelled_at
     await batch_obj.asave()
 
-    # Build response from upstream data, ensuring file IDs match our local records
-    response_data = remote_batch.model_dump()
-    response_data["input_file_id"] = batch_obj.input_file_id
+    # Ensure file ID in the response data matches our local records
+    remote_batch.input_file_id = batch_obj.input_file_id
 
-    return RawJsonResponse(response_data, status=200)
+    return RawJsonResponse(remote_batch, status=200)

--- a/aqueduct/gateway/views/batches.py
+++ b/aqueduct/gateway/views/batches.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods, require_POST
@@ -21,6 +20,7 @@ from .decorators import (
 )
 from .errors import error_response
 from .files import sync_batch_file_if_needed
+from .utils import RawJsonResponse
 
 
 @csrf_exempt
@@ -36,7 +36,7 @@ async def batches(
     pydantic_model: BatchCreateParams | None = None,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /batches - list user's batches from local DB
     POST /batches - create a new batch on upstream
@@ -52,7 +52,7 @@ async def batches(
             async for b in batch_qs.order_by("-created_at").select_related("input_file")
         ]
 
-        return JsonResponse(
+        return RawJsonResponse(
             {"object": "list", "data": batch_objects, "has_more": False}, status=200
         )
 
@@ -128,7 +128,7 @@ async def batches(
     response_data = remote_batch.model_dump()
     response_data["input_file_id"] = file_obj.id
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -139,7 +139,7 @@ async def batches(
 @catch_router_exceptions
 async def batch(
     request: ASGIRequest, token: Token, batch_id: str, *args: Any, **kwargs: Any
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /batches/{batch_id} - retrieve a batch from upstream
 
@@ -187,7 +187,7 @@ async def batch(
     if error_file_obj:
         response_data["error_file_id"] = error_file_obj.id
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -198,7 +198,7 @@ async def batch(
 @catch_router_exceptions
 async def batch_cancel(
     request: ASGIRequest, token: Token, batch_id: str, *args: Any, **kwargs: Any
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     POST /batches/{batch_id}/cancel - cancel a batch on upstream
 
@@ -236,4 +236,4 @@ async def batch_cancel(
     response_data = remote_batch.model_dump()
     response_data["input_file_id"] = batch_obj.input_file_id
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)

--- a/aqueduct/gateway/views/chat_completions.py
+++ b/aqueduct/gateway/views/chat_completions.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
@@ -25,7 +24,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import RawJsonResponse, _get_token_usage, _openai_stream
+from .utils import RawJsonResponse, RawStreamingResponse, get_token_usage
 
 
 @csrf_exempt
@@ -47,19 +46,16 @@ async def chat_completions(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> RawJsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | RawStreamingResponse:
     router = get_router()
     chat_completion: CustomStreamWrapper | ModelResponse = await router.acompletion(
         **pydantic_model
     )
     if isinstance(chat_completion, CustomStreamWrapper):
-        return StreamingHttpResponse(
-            streaming_content=_openai_stream(stream=chat_completion, request_log=request_log),
-            content_type="text/event-stream",
-        )
+        return RawStreamingResponse(streaming_content=chat_completion, request_log=request_log)
     if isinstance(chat_completion, ModelResponse):
         data = chat_completion.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = _get_token_usage(data)
+        request_log.token_usage = get_token_usage(data)
         return RawJsonResponse(data=data, status=200)
     raise NotImplementedError(
         f"Completion for response type {type(chat_completion)} is not implemented."

--- a/aqueduct/gateway/views/chat_completions.py
+++ b/aqueduct/gateway/views/chat_completions.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
@@ -25,7 +25,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import _get_token_usage, _openai_stream
+from .utils import RawJsonResponse, _get_token_usage, _openai_stream
 
 
 @csrf_exempt
@@ -47,7 +47,7 @@ async def chat_completions(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | StreamingHttpResponse:
     router = get_router()
     chat_completion: CustomStreamWrapper | ModelResponse = await router.acompletion(
         **pydantic_model
@@ -60,7 +60,7 @@ async def chat_completions(
     if isinstance(chat_completion, ModelResponse):
         data = chat_completion.model_dump(exclude_none=True, exclude_unset=True)
         request_log.token_usage = _get_token_usage(data)
-        return JsonResponse(data=data, status=200)
+        return RawJsonResponse(data=data, status=200)
     raise NotImplementedError(
         f"Completion for response type {type(chat_completion)} is not implemented."
     )

--- a/aqueduct/gateway/views/chat_completions.py
+++ b/aqueduct/gateway/views/chat_completions.py
@@ -54,9 +54,8 @@ async def chat_completions(
     if isinstance(chat_completion, CustomStreamWrapper):
         return RawStreamingResponse(streaming_content=chat_completion, request_log=request_log)
     if isinstance(chat_completion, ModelResponse):
-        data = chat_completion.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = get_token_usage(data)
-        return RawJsonResponse(data=data, status=200)
+        request_log.token_usage = get_token_usage(chat_completion)
+        return RawJsonResponse(data=chat_completion, status=200)
     raise NotImplementedError(
         f"Completion for response type {type(chat_completion)} is not implemented."
     )

--- a/aqueduct/gateway/views/completions.py
+++ b/aqueduct/gateway/views/completions.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from litellm import TextCompletionStreamWrapper
@@ -23,7 +23,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import _get_token_usage, _openai_stream
+from .utils import RawJsonResponse, _get_token_usage, _openai_stream
 
 
 @csrf_exempt
@@ -43,7 +43,7 @@ async def completions(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | StreamingHttpResponse:
     router = get_router()
     completion: (
         TextCompletionResponse | TextCompletionStreamWrapper
@@ -56,7 +56,7 @@ async def completions(
     if isinstance(completion, TextCompletionResponse):
         data = completion.model_dump(exclude_none=True, exclude_unset=True)
         request_log.token_usage = _get_token_usage(data)
-        return JsonResponse(data=data, status=200)
+        return RawJsonResponse(data=data, status=200)
     raise NotImplementedError(
         f"Completion for response type {type(completion)} is not implemented."
     )

--- a/aqueduct/gateway/views/completions.py
+++ b/aqueduct/gateway/views/completions.py
@@ -50,9 +50,8 @@ async def completions(
     if isinstance(completion, TextCompletionStreamWrapper):
         return RawStreamingResponse(streaming_content=completion, request_log=request_log)
     if isinstance(completion, TextCompletionResponse):
-        data = completion.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = get_token_usage(data)
-        return RawJsonResponse(data=data, status=200)
+        request_log.token_usage = get_token_usage(completion)
+        return RawJsonResponse(data=completion, status=200)
     raise NotImplementedError(
         f"Completion for response type {type(completion)} is not implemented."
     )

--- a/aqueduct/gateway/views/completions.py
+++ b/aqueduct/gateway/views/completions.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from litellm import TextCompletionStreamWrapper
@@ -23,7 +22,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import RawJsonResponse, _get_token_usage, _openai_stream
+from .utils import RawJsonResponse, RawStreamingResponse, get_token_usage
 
 
 @csrf_exempt
@@ -43,19 +42,16 @@ async def completions(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> RawJsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | RawStreamingResponse:
     router = get_router()
     completion: (
         TextCompletionResponse | TextCompletionStreamWrapper
     ) = await router.atext_completion(**pydantic_model)
     if isinstance(completion, TextCompletionStreamWrapper):
-        return StreamingHttpResponse(
-            streaming_content=_openai_stream(stream=completion, request_log=request_log),
-            headers={"Content-Type": "text/event-stream"},
-        )
+        return RawStreamingResponse(streaming_content=completion, request_log=request_log)
     if isinstance(completion, TextCompletionResponse):
         data = completion.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = _get_token_usage(data)
+        request_log.token_usage = get_token_usage(data)
         return RawJsonResponse(data=data, status=200)
     raise NotImplementedError(
         f"Completion for response type {type(completion)} is not implemented."

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -5,11 +5,11 @@ import logging
 import re
 import sys
 import time
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Iterable
+from collections.abc import Callable, Coroutine, Iterable
 from datetime import timedelta
 from functools import wraps
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 
 import httpx
 import litellm
@@ -24,6 +24,7 @@ from django.db.models import Count, Sum
 from django.http import HttpResponse, StreamingHttpResponse
 from django.urls import reverse
 from django.utils import timezone
+from litellm.types.utils import ModelResponseStream
 from mcp.types import JSONRPCMessage
 from openai.types.chat import ChatCompletionStreamOptionsParam
 from openai.types.chat.chat_completion_content_part_param import FileFile
@@ -41,12 +42,17 @@ from gateway.config import (
     resolve_model_alias,
 )
 from gateway.views.errors import error_response
-from gateway.views.utils import RawJsonResponse, get_response_from_cache, in_wildcard
+from gateway.views.utils import (
+    RawJsonResponse,
+    RawStreamingResponse,
+    get_response_from_cache,
+    in_wildcard,
+)
 from management.models import FileObject, Request, Token, VectorStore
 
 log = logging.getLogger("aqueduct")
 
-ViewResult = HttpResponse | StreamingHttpResponse | RawJsonResponse
+ViewResult = HttpResponse | StreamingHttpResponse | RawJsonResponse | RawStreamingResponse
 AsyncView = Callable[..., Coroutine[Any, Any, ViewResult]]
 Decorator = Callable[[AsyncView], AsyncView]
 
@@ -717,7 +723,7 @@ def catch_router_exceptions(view_func: AsyncView) -> AsyncView:
     return wrapper
 
 
-def _normalize_choice_message(message: dict[str, Any]) -> bool:
+def _normalize_reasoning_in_message(message: dict[str, Any]) -> bool:
     """Ensure both 'reasoning' and 'reasoning_content' are present if either exists.
 
     Returns True if the message was modified.
@@ -749,40 +755,18 @@ def normalize_reasoning_fields(view_func: AsyncView) -> AsyncView:
     async def wrapper(request: ASGIRequest, *args: Any, **kwargs: Any) -> ViewResult:
         result = await view_func(request, *args, **kwargs)
 
-        if isinstance(result, StreamingHttpResponse):
-            original_stream = cast("AsyncIterator[bytes]", result.streaming_content)
+        if isinstance(result, RawStreamingResponse):
 
-            async def normalized_stream() -> AsyncGenerator[str, None]:
-                async for chunk in original_stream:
-                    # Chunks may be bytes or str; normalize to str for parsing
-                    if isinstance(chunk, bytes):
-                        chunk_str = chunk.decode("utf-8")
-                    else:
-                        chunk_str = chunk
+            def _normalized_stream(chunk: ModelResponseStream) -> ModelResponseStream:
+                choices = chunk.get("choices", [])
+                for choice in choices:
+                    # Streaming chunks use "delta"; final chunks use "message"
+                    message = choice.get("delta") or {}
+                    if message:
+                        _normalize_reasoning_in_message(message)
+                return chunk
 
-                    if chunk_str.startswith("data: ") and not chunk_str.startswith("data: [DONE]"):
-                        try:
-                            data_str = chunk_str.removeprefix("data: ")
-                            data_str = data_str.rstrip("\n")
-                            chunk_data = json.loads(data_str)
-
-                            choices = chunk_data.get("choices", [])
-                            for choice in choices:
-                                # Streaming chunks use "delta"; final chunks use "message"
-                                message = choice.get("delta") or {}
-                                if message:
-                                    _normalize_choice_message(message)
-
-                            modified_chunk = f"data: {json.dumps(chunk_data)}\n\n"
-                        except (json.JSONDecodeError, UnicodeDecodeError):
-                            modified_chunk = chunk_str
-
-                    else:
-                        modified_chunk = chunk_str
-
-                    yield modified_chunk
-
-            result.streaming_content = normalized_stream()
+            result.transforms.append(_normalized_stream)
 
         elif isinstance(result, RawJsonResponse):
             content = result.content
@@ -790,7 +774,7 @@ def normalize_reasoning_fields(view_func: AsyncView) -> AsyncView:
             for choice in choices:
                 message = choice.get("message", {})
                 if message:
-                    _normalize_choice_message(message)
+                    _normalize_reasoning_in_message(message)
             result = RawJsonResponse(content, **result.kwargs)
 
         return result

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Coroutine, Iterable
 from datetime import timedelta
 from functools import wraps
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import litellm
@@ -24,7 +24,7 @@ from django.db.models import Count, Sum
 from django.http import HttpResponse, StreamingHttpResponse
 from django.urls import reverse
 from django.utils import timezone
-from litellm.types.utils import ModelResponseStream
+from litellm.types.utils import ModelResponse, ModelResponseStream
 from mcp.types import JSONRPCMessage
 from openai.types.chat import ChatCompletionStreamOptionsParam
 from openai.types.chat.chat_completion_content_part_param import FileFile
@@ -769,13 +769,12 @@ def normalize_reasoning_fields(view_func: AsyncView) -> AsyncView:
             result.transforms.append(_normalized_stream)
 
         elif isinstance(result, RawJsonResponse):
-            content = result.content
+            content = cast("dict[str, Any] | ModelResponse", result.content)
             choices = content.get("choices", [])
             for choice in choices:
                 message = choice.get("message", {})
                 if message:
                     _normalize_reasoning_in_message(message)
-            result = RawJsonResponse(content, **result.kwargs)
 
         return result
 

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -891,7 +891,7 @@ def mcp_transport_security(view_func: AsyncView) -> AsyncView:
 def parse_jsonrpc_message(view_func: AsyncView) -> AsyncView:
     @wraps(view_func)
     async def wrapper(request: ASGIRequest, *args: Any, **kwargs: Any) -> ViewResult:
-        session_id = request.headers.get("Mcp-Session-Id")
+        session_id = request.headers.get("mcp-session-id")
         kwargs["session_id"] = session_id
 
         if request.method != "POST":

--- a/aqueduct/gateway/views/decorators.py
+++ b/aqueduct/gateway/views/decorators.py
@@ -21,7 +21,7 @@ from django.core.cache import cache
 from django.core.files.uploadedfile import UploadedFile
 from django.core.handlers.asgi import ASGIRequest
 from django.db.models import Count, Sum
-from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.urls import reverse
 from django.utils import timezone
 from mcp.types import JSONRPCMessage
@@ -41,12 +41,12 @@ from gateway.config import (
     resolve_model_alias,
 )
 from gateway.views.errors import error_response
-from gateway.views.utils import get_response_from_cache, in_wildcard
+from gateway.views.utils import RawJsonResponse, get_response_from_cache, in_wildcard
 from management.models import FileObject, Request, Token, VectorStore
 
 log = logging.getLogger("aqueduct")
 
-ViewResult = HttpResponse | StreamingHttpResponse
+ViewResult = HttpResponse | StreamingHttpResponse | RawJsonResponse
 AsyncView = Callable[..., Coroutine[Any, Any, ViewResult]]
 Decorator = Callable[[AsyncView], AsyncView]
 
@@ -419,7 +419,7 @@ def log_request(view_func: AsyncView) -> AsyncView:
         log.debug("Initial request log object created.")
 
         response_start_time = time.monotonic()
-        result: HttpResponse | StreamingHttpResponse = await view_func(request, *args, **kwargs)
+        result: ViewResult = await view_func(request, *args, **kwargs)
         end_time = time.monotonic()
 
         assert "request_start" in kwargs, (
@@ -650,7 +650,7 @@ def catch_router_exceptions(view_func: AsyncView) -> AsyncView:
         s = re.sub(r"Lite-?[lL][lL][mM]", "Aqueduct", s)  # uppercase
         return re.sub(r"lite-?[lL][lL][mM]", "aqueduct", s)  # lowercase
 
-    def _exception_response(e: Exception, status: int) -> HttpResponse:
+    def _exception_response(e: Exception, status: int) -> RawJsonResponse:
         """Convert an openai/litellm exception to an OpenAI-compatible JsonResponse.
 
         The openai SDK parses ``code``, ``param``, and ``type`` from the
@@ -784,15 +784,14 @@ def normalize_reasoning_fields(view_func: AsyncView) -> AsyncView:
 
             result.streaming_content = normalized_stream()
 
-        elif isinstance(result, JsonResponse):
-            content = json.loads(result.content)
+        elif isinstance(result, RawJsonResponse):
+            content = result.content
             choices = content.get("choices", [])
             for choice in choices:
                 message = choice.get("message", {})
                 if message:
                     _normalize_choice_message(message)
-
-            result = JsonResponse(content, status=result.status_code)
+            result = RawJsonResponse(content, **result.kwargs)
 
         return result
 

--- a/aqueduct/gateway/views/embeddings.py
+++ b/aqueduct/gateway/views/embeddings.py
@@ -46,6 +46,5 @@ async def embeddings(
 ) -> RawJsonResponse:
     router = get_router()
     embedding: EmbeddingResponse = await router.aembedding(**pydantic_model)
-    data = embedding.model_dump(exclude_none=True, exclude_unset=True)
-    request_log.token_usage = get_token_usage(data)
-    return RawJsonResponse(data=data, status=200)
+    request_log.token_usage = get_token_usage(embedding)
+    return RawJsonResponse(data=embedding, status=200)

--- a/aqueduct/gateway/views/embeddings.py
+++ b/aqueduct/gateway/views/embeddings.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from pydantic import TypeAdapter
@@ -21,7 +20,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import _get_token_usage
+from .utils import RawJsonResponse, _get_token_usage
 
 if TYPE_CHECKING:
     from litellm.types.utils import EmbeddingResponse
@@ -44,9 +43,9 @@ async def embeddings(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     router = get_router()
     embedding: EmbeddingResponse = await router.aembedding(**pydantic_model)
     data = embedding.model_dump(exclude_none=True, exclude_unset=True)
     request_log.token_usage = _get_token_usage(data)
-    return JsonResponse(data=data, status=200)
+    return RawJsonResponse(data=data, status=200)

--- a/aqueduct/gateway/views/embeddings.py
+++ b/aqueduct/gateway/views/embeddings.py
@@ -20,7 +20,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import RawJsonResponse, _get_token_usage
+from .utils import RawJsonResponse, get_token_usage
 
 if TYPE_CHECKING:
     from litellm.types.utils import EmbeddingResponse
@@ -47,5 +47,5 @@ async def embeddings(
     router = get_router()
     embedding: EmbeddingResponse = await router.aembedding(**pydantic_model)
     data = embedding.model_dump(exclude_none=True, exclude_unset=True)
-    request_log.token_usage = _get_token_usage(data)
+    request_log.token_usage = get_token_usage(data)
     return RawJsonResponse(data=data, status=200)

--- a/aqueduct/gateway/views/errors.py
+++ b/aqueduct/gateway/views/errors.py
@@ -1,5 +1,6 @@
-from django.http import JsonResponse
 from openai.types import ErrorObject
+
+from gateway.views.utils import RawJsonResponse
 
 
 def error_response(
@@ -8,12 +9,12 @@ def error_response(
     param: str | None = None,
     code: str | None = None,
     status: int = 400,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """Return an OpenAI-compatible error response."""
     if error_type is None:
         error_type = _status_to_error_type(status)
     error = ErrorObject(message=message, type=error_type, param=param, code=code)
-    return JsonResponse({"error": error.model_dump(exclude_none=True)}, status=status)
+    return RawJsonResponse({"error": error.model_dump(exclude_none=True)}, status=status)
 
 
 def _status_to_error_type(status: int) -> str:

--- a/aqueduct/gateway/views/files.py
+++ b/aqueduct/gateway/views/files.py
@@ -163,11 +163,9 @@ async def files(
                 .select_related("token")
             )
 
-        serialized_files = [
-            file.model.model_dump(exclude_none=True, exclude_unset=True) async for file in qs
-        ]
+        file_models = [file.model async for file in qs]
         return RawJsonResponse(
-            {"object": "list", "data": serialized_files, "has_more": False}, status=200
+            {"object": "list", "data": file_models, "has_more": False}, status=200
         )
 
     # POST /files
@@ -244,9 +242,7 @@ async def files(
     await file_obj.asave()
 
     # Return response with upstream ID
-    response_data = file_obj.model.model_dump(exclude_none=True, exclude_unset=True)
-
-    return RawJsonResponse(response_data, status=200)
+    return RawJsonResponse(file_obj.model, status=200)
 
 
 @csrf_exempt
@@ -287,8 +283,7 @@ async def file(
             return error_response("File not found upstream.", param="file_id", status=404)
 
         # Return response with upstream ID (same as file_obj.id)
-        response_data = remote_file.model_dump()
-        return RawJsonResponse(response_data, status=200)
+        return RawJsonResponse(remote_file, status=200)
 
     await file_obj.adelete_upstream(client)
 

--- a/aqueduct/gateway/views/files.py
+++ b/aqueduct/gateway/views/files.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, Optional
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
 from django.db.models import Sum
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods
@@ -26,6 +26,7 @@ from .decorators import (
     tos_accepted,
 )
 from .errors import error_response
+from .utils import RawJsonResponse
 
 
 class FilesCreateParams(BaseModel):
@@ -142,7 +143,7 @@ async def files(
     file_preview: str | None = None,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     try:
         client = get_files_api_client()
     except ValueError:
@@ -165,7 +166,7 @@ async def files(
         serialized_files = [
             file.model.model_dump(exclude_none=True, exclude_unset=True) async for file in qs
         ]
-        return JsonResponse(
+        return RawJsonResponse(
             {"object": "list", "data": serialized_files, "has_more": False}, status=200
         )
 
@@ -245,7 +246,7 @@ async def files(
     # Return response with upstream ID
     response_data = file_obj.model.model_dump(exclude_none=True, exclude_unset=True)
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -256,7 +257,7 @@ async def files(
 @catch_router_exceptions
 async def file(
     request: ASGIRequest, token: Token, file_id: str, *args: Any, **kwargs: Any
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     Retrieve or delete a specific file.
 
@@ -287,7 +288,7 @@ async def file(
 
         # Return response with upstream ID (same as file_obj.id)
         response_data = remote_file.model_dump()
-        return JsonResponse(response_data, status=200)
+        return RawJsonResponse(response_data, status=200)
 
     await file_obj.adelete_upstream(client)
 
@@ -296,7 +297,7 @@ async def file(
 
     # Return response with upstream ID
     response_data = {"id": file_id, "object": "file", "deleted": True}
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -307,7 +308,7 @@ async def file(
 @catch_router_exceptions
 async def file_content(
     request: ASGIRequest, token: Token, file_id: str, *args: Any, **kwargs: Any
-) -> HttpResponse | JsonResponse:
+) -> HttpResponse | RawJsonResponse:
     """
     Retrieve the content of a specific file.
 

--- a/aqueduct/gateway/views/image_generation.py
+++ b/aqueduct/gateway/views/image_generation.py
@@ -20,7 +20,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import RawJsonResponse, _get_token_usage, oai_client_from_body
+from .utils import RawJsonResponse, get_token_usage, oai_client_from_body
 
 log = logging.getLogger("aqueduct")
 
@@ -73,6 +73,6 @@ async def image_generation(
         ) from err
 
     data = resp.model_dump(exclude_unset=True)
-    request_log.token_usage = _get_token_usage(data)
+    request_log.token_usage = get_token_usage(data)
 
     return RawJsonResponse(data)

--- a/aqueduct/gateway/views/image_generation.py
+++ b/aqueduct/gateway/views/image_generation.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any
 
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from litellm import BadRequestError
@@ -21,7 +20,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import _get_token_usage, oai_client_from_body
+from .utils import RawJsonResponse, _get_token_usage, oai_client_from_body
 
 log = logging.getLogger("aqueduct")
 
@@ -42,7 +41,7 @@ async def image_generation(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     if pydantic_model.get("stream"):
         # LiteLLM cannot parse a Stream response, so we don't support streaming for now
         raise BadRequestError(
@@ -76,4 +75,4 @@ async def image_generation(
     data = resp.model_dump(exclude_unset=True)
     request_log.token_usage = _get_token_usage(data)
 
-    return JsonResponse(data)
+    return RawJsonResponse(data)

--- a/aqueduct/gateway/views/image_generation.py
+++ b/aqueduct/gateway/views/image_generation.py
@@ -72,7 +72,7 @@ async def image_generation(
             "Unexpected argument in request body", pydantic_model.get("model"), llm_provider=None
         ) from err
 
-    data = resp.model_dump(exclude_unset=True)
-    request_log.token_usage = get_token_usage(data)
+    # TODO # data = resp.model_dump(exclude_unset=True)
+    request_log.token_usage = get_token_usage(resp)
 
-    return RawJsonResponse(data)
+    return RawJsonResponse(resp)

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -10,7 +10,6 @@ import anyio
 import httpx
 from anyio import ClosedResourceError
 from django.core.handlers.asgi import ASGIRequest
-from django.http import StreamingHttpResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
@@ -19,7 +18,7 @@ from mcp.shared.message import SessionMessage
 from mcp.types import CONNECTION_CLOSED, ErrorData, JSONRPCError, JSONRPCMessage, JSONRPCRequest
 from pydantic import TypeAdapter
 
-from gateway.views.utils import RawJsonResponse
+from gateway.views.utils import RawJsonResponse, RawStreamingResponse
 
 if TYPE_CHECKING:
     from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
@@ -346,7 +345,7 @@ class MCPSessionManager:
             self._cleanup_task = asyncio.create_task(self._cleanup_idle_sessions())
 
     async def _cleanup_idle_sessions(self, max_idle_seconds: int = 3600) -> None:
-        """Background task to cleanup idle sessions."""
+        """Background task to clean up idle sessions."""
         while True:
             await asyncio.sleep(60)
 
@@ -535,7 +534,7 @@ def _validate_session(
     return None
 
 
-async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenerator[str, None]:
+async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenerator[dict[str, Any]]:
     """Stream MCP messages via Server-Sent Events with lifecycle coordination."""
     log.info("SSE stream started for session %s", session_id)
     session = await session_manager.get_session_with_retry(session_id)
@@ -553,9 +552,7 @@ async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenera
                 message=f"Session not ready (state: {session.state.value if session else 'None'})",
             ),
         )
-
-        # TODO!!
-        yield f"data: {error_msg.model_dump_json(exclude_none=True)}\n\n"
+        yield error_msg.model_dump(exclude_none=True)
         return
 
     # Register stream lifetime to coordinate with session termination
@@ -565,18 +562,18 @@ async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenera
     while True:
         try:
             message: SessionMessage | Exception = await session_manager.receive_message(session_id)
-            message_json = parse_session_message(message, request_id, session_id, json=True)
-            yield f"data: {message_json}\n\n"
+            parsed_msg = parse_session_message(message, request_id, session_id)
+            yield cast("dict[str, Any]", parsed_msg)
         except (ClosedResourceError, httpx.HTTPStatusError, MCPSessionError) as e:
             log.info("SSE stream for session %s ended: %s", session_id, e)
             # Send proper session end notification
-            end_msg = parse_session_message(e, request_id, session_id, json=True)
-            yield f"data: {end_msg}\n\n"
+            end_msg = parse_session_message(e, request_id, session_id)
+            yield cast("dict[str, Any]", end_msg)
             break  # Session is gone, stop the stream
         except Exception as e:
             log.exception("SSE stream for session %s unexpected error: %s", session_id, e)
-            error_data = parse_session_message(e, request_id, session_id, json=True)
-            yield f"data: {error_data}\n\n"
+            error_data = parse_session_message(e, request_id, session_id)
+            yield cast("dict[str, Any]", error_data)
             continue  # Keep streaming
         finally:
             # Signal that this operation is done
@@ -595,7 +592,7 @@ async def _ensure_session_manager_started() -> None:
 
 async def handle_get_request(
     name: str, request_id: str | int, session_id: str
-) -> RawJsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | RawStreamingResponse:
     """Return SSE stream for an existing session.
 
     See: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server
@@ -610,10 +607,8 @@ async def handle_get_request(
 
     log.info("MCP GET %s - SSE stream for existing session %s", name, session_id)
     headers = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
-    return StreamingHttpResponse(
-        streaming_content=_mcp_sse_stream(request_id, session_id),  # TODO!
-        request_log=None,  # TODO:
-        headers=headers,
+    return RawStreamingResponse(
+        streaming_content=_mcp_sse_stream(request_id, session_id), request_log=None, headers=headers
     )
 
 
@@ -725,7 +720,7 @@ async def mcp_server(
     is_initialize: bool = False,
     *args: Any,
     **kwargs: Any,
-) -> RawJsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | RawStreamingResponse:
     """
     Handles GET, POST and DELETE requests for /mcp-servers/{name}/mcp path.
     """

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -4,7 +4,7 @@ import uuid
 from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
 from enum import Enum
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import anyio
 import httpx
@@ -490,11 +490,8 @@ class MCPSessionManager:
 
 
 def parse_session_message(
-    received_message: SessionMessage | Exception,
-    request_id: str | int,
-    session_id: str,
-    json: bool = False,
-) -> dict[str, Any] | str:
+    received_message: SessionMessage | Exception, request_id: str | int, session_id: str
+) -> dict[str, Any]:
     jsonrpc_message: JSONRPCError | JSONRPCMessage
     if isinstance(received_message, Exception):
         log.error("Session %s returned exception: %s", session_id, received_message)
@@ -506,10 +503,6 @@ def parse_session_message(
     else:
         jsonrpc_message = received_message.message
 
-    if json:
-        # the returned message is a str
-        return jsonrpc_message.model_dump_json(exclude_none=True)
-    # Else, the return type is dict[str, Any]
     return jsonrpc_message.model_dump(exclude_none=True)
 
 
@@ -562,18 +555,15 @@ async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenera
     while True:
         try:
             message: SessionMessage | Exception = await session_manager.receive_message(session_id)
-            parsed_msg = parse_session_message(message, request_id, session_id)
-            yield cast("dict[str, Any]", parsed_msg)
+            yield parse_session_message(message, request_id, session_id)
         except (ClosedResourceError, httpx.HTTPStatusError, MCPSessionError) as e:
             log.info("SSE stream for session %s ended: %s", session_id, e)
             # Send proper session end notification
-            end_msg = parse_session_message(e, request_id, session_id)
-            yield cast("dict[str, Any]", end_msg)
+            yield parse_session_message(e, request_id, session_id)
             break  # Session is gone, stop the stream
         except Exception as e:
             log.exception("SSE stream for session %s unexpected error: %s", session_id, e)
-            error_data = parse_session_message(e, request_id, session_id)
-            yield cast("dict[str, Any]", error_data)
+            yield parse_session_message(e, request_id, session_id)
             continue  # Keep streaming
         finally:
             # Signal that this operation is done
@@ -668,10 +658,7 @@ async def handle_post_request(
         if isinstance(json_rpc_message.root, JSONRPCRequest):
             received_message = await session_manager.receive_message(session_id)
             session_id_str: str = session_id if session_id is not None else ""
-            response_data = parse_session_message(
-                received_message, request_id, session_id_str, json=False
-            )
-            response_data = cast("dict[str, Any]", response_data)
+            response_data = parse_session_message(received_message, request_id, session_id_str)
             response = RawJsonResponse(response_data)
         else:
             # If the request was a notification, return 202
@@ -680,8 +667,7 @@ async def handle_post_request(
     except (ClosedResourceError, httpx.HTTPStatusError, MCPSessionError) as e:
         # Transport errors should be converted to JSON-RPC errors
         log.exception("Transport error for MCP server '%s': %s", name, e)
-        session_error_response = parse_session_message(e, request_id, session_id_str, json=False)
-        session_error_response = cast("dict[str, Any]", session_error_response)
+        session_error_response = parse_session_message(e, request_id, session_id_str)
         response = RawJsonResponse(session_error_response, status=200)  # 200 for JSON-RPC errors
     finally:
         if operation_registered:

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -690,7 +690,7 @@ async def handle_post_request(
         if operation_registered:
             session.register_operation_done()
 
-    response.headers["mcp-session-id"] = session_id if session_id is not None else ""
+    response.headers[MCP_SESSION_ID] = session_id if session_id is not None else ""
     return response
 
 

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -10,7 +10,7 @@ import anyio
 import httpx
 from anyio import ClosedResourceError
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import StreamingHttpResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
@@ -622,7 +622,7 @@ async def handle_post_request(
     request_id: str | int,
     session_id: str | None,
     is_initialize: bool,
-) -> JsonResponse | RawJsonResponse:
+) -> RawJsonResponse:
     """Send a message to MCP session or initialize new session when it is an initialization request.
 
     See: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server
@@ -695,7 +695,7 @@ async def handle_post_request(
     return response
 
 
-async def handle_delete_request(name: str, session_id: str | None = None) -> JsonResponse:
+async def handle_delete_request(name: str, session_id: str | None = None) -> RawJsonResponse:
     """Terminate MCP session.
 
     See: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
@@ -704,7 +704,7 @@ async def handle_delete_request(name: str, session_id: str | None = None) -> Jso
 
     log.info("MCP DELETE %s - Closing session %s", name, session_id)
     await session_manager.terminate_session(session_id)
-    return JsonResponse({"status": "session_terminated"})
+    return RawJsonResponse({"status": "session_terminated"})
 
 
 @csrf_exempt
@@ -724,7 +724,7 @@ async def mcp_server(
     is_initialize: bool = False,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse | RawJsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | StreamingHttpResponse:
     """
     Handles GET, POST and DELETE requests for /mcp-servers/{name}/mcp path.
     """

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -554,6 +554,7 @@ async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenera
             ),
         )
 
+        # TODO!!
         yield f"data: {error_msg.model_dump_json(exclude_none=True)}\n\n"
         return
 
@@ -610,8 +611,8 @@ async def handle_get_request(
     log.info("MCP GET %s - SSE stream for existing session %s", name, session_id)
     headers = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
     return StreamingHttpResponse(
-        streaming_content=_mcp_sse_stream(request_id, session_id),
-        content_type="text/event-stream",
+        streaming_content=_mcp_sse_stream(request_id, session_id),  # TODO!
+        request_log=None,  # TODO:
         headers=headers,
     )
 

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -491,19 +491,15 @@ class MCPSessionManager:
 
 def parse_session_message(
     received_message: SessionMessage | Exception, request_id: str | int, session_id: str
-) -> dict[str, Any]:
-    jsonrpc_message: JSONRPCError | JSONRPCMessage
+) -> JSONRPCError | JSONRPCMessage:
     if isinstance(received_message, Exception):
         log.error("Session %s returned exception: %s", session_id, received_message)
-        jsonrpc_message = JSONRPCError(
+        return JSONRPCError(
             jsonrpc="2.0",
             id=request_id,
             error=ErrorData(code=CONNECTION_CLOSED, message=str(received_message)),
         )
-    else:
-        jsonrpc_message = received_message.message
-
-    return jsonrpc_message.model_dump(exclude_none=True)
+    return received_message.message
 
 
 def _validate_session(
@@ -527,7 +523,9 @@ def _validate_session(
     return None
 
 
-async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenerator[dict[str, Any]]:
+async def _mcp_sse_stream(
+    request_id: str | int, session_id: str
+) -> AsyncGenerator[JSONRPCError | JSONRPCMessage]:
     """Stream MCP messages via Server-Sent Events with lifecycle coordination."""
     log.info("SSE stream started for session %s", session_id)
     session = await session_manager.get_session_with_retry(session_id)
@@ -545,7 +543,7 @@ async def _mcp_sse_stream(request_id: str | int, session_id: str) -> AsyncGenera
                 message=f"Session not ready (state: {session.state.value if session else 'None'})",
             ),
         )
-        yield error_msg.model_dump(exclude_none=True)
+        yield error_msg
         return
 
     # Register stream lifetime to coordinate with session termination
@@ -648,8 +646,9 @@ async def handle_post_request(
         session.register_operation_start()
         operation_registered = True
 
+    log.debug("Sending message to session %s", session_id)
+    session_id_str: str = session_id if session_id is not None else ""
     try:
-        log.debug("Sending message to session %s", session_id)
         session_message = SessionMessage(json_rpc_message)
         await session_manager.send_message(session_id, session_message)
 
@@ -657,7 +656,6 @@ async def handle_post_request(
         # Per MCP spec: "The server MUST NOT send a response to notifications"
         if isinstance(json_rpc_message.root, JSONRPCRequest):
             received_message = await session_manager.receive_message(session_id)
-            session_id_str: str = session_id if session_id is not None else ""
             response_data = parse_session_message(received_message, request_id, session_id_str)
             response = RawJsonResponse(response_data)
         else:

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -19,6 +19,8 @@ from mcp.shared.message import SessionMessage
 from mcp.types import CONNECTION_CLOSED, ErrorData, JSONRPCError, JSONRPCMessage, JSONRPCRequest
 from pydantic import TypeAdapter
 
+from gateway.views.utils import RawJsonResponse
+
 if TYPE_CHECKING:
     from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
@@ -490,7 +492,7 @@ class MCPSessionManager:
 
 def parse_session_message(
     received_message: SessionMessage | Exception,
-    reqeust_id: str | int,
+    request_id: str | int,
     session_id: str,
     json: bool = False,
 ) -> dict[str, Any] | str:
@@ -499,7 +501,7 @@ def parse_session_message(
         log.error("Session %s returned exception: %s", session_id, received_message)
         jsonrpc_message = JSONRPCError(
             jsonrpc="2.0",
-            id=reqeust_id,
+            id=request_id,
             error=ErrorData(code=CONNECTION_CLOSED, message=str(received_message)),
         )
     else:
@@ -515,7 +517,7 @@ def parse_session_message(
 
 def _validate_session(
     session: ManagedMCPSession | None, session_id: str | None, name: str
-) -> JsonResponse | None:
+) -> RawJsonResponse | None:
     if not session:
         log.warning("Session %s not found for MCP server '%s'", session_id, name)
         return error_response("Session not found", status=404)
@@ -593,7 +595,7 @@ async def _ensure_session_manager_started() -> None:
 
 async def handle_get_request(
     name: str, request_id: str | int, session_id: str
-) -> JsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | StreamingHttpResponse:
     """Return SSE stream for an existing session.
 
     See: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server
@@ -621,7 +623,7 @@ async def handle_post_request(
     request_id: str | int,
     session_id: str | None,
     is_initialize: bool,
-) -> JsonResponse:
+) -> JsonResponse | RawJsonResponse:
     """Send a message to MCP session or initialize new session when it is an initialization request.
 
     See: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server
@@ -721,7 +723,7 @@ async def mcp_server(
     is_initialize: bool = False,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse | StreamingHttpResponse:
+) -> JsonResponse | RawJsonResponse | StreamingHttpResponse:
     """
     Handles GET, POST and DELETE requests for /mcp-servers/{name}/mcp path.
     """

--- a/aqueduct/gateway/views/mcp.py
+++ b/aqueduct/gateway/views/mcp.py
@@ -4,7 +4,7 @@ import uuid
 from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import anyio
 import httpx
@@ -507,12 +507,11 @@ def parse_session_message(
     else:
         jsonrpc_message = received_message.message
 
-    msg: dict[str, Any] | str
     if json:
-        msg = jsonrpc_message.model_dump_json(exclude_none=True)
-    else:
-        msg = jsonrpc_message.model_dump(exclude_none=True)
-    return msg
+        # the returned message is a str
+        return jsonrpc_message.model_dump_json(exclude_none=True)
+    # Else, the return type is dict[str, Any]
+    return jsonrpc_message.model_dump(exclude_none=True)
 
 
 def _validate_session(
@@ -676,16 +675,18 @@ async def handle_post_request(
             response_data = parse_session_message(
                 received_message, request_id, session_id_str, json=False
             )
-            response = JsonResponse(response_data)
+            response_data = cast("dict[str, Any]", response_data)
+            response = RawJsonResponse(response_data)
         else:
             # If the request was a notification, return 202
-            response = JsonResponse({"status": "accepted"}, status=202)
+            response = RawJsonResponse({"status": "accepted"}, status=202)
 
     except (ClosedResourceError, httpx.HTTPStatusError, MCPSessionError) as e:
         # Transport errors should be converted to JSON-RPC errors
         log.exception("Transport error for MCP server '%s': %s", name, e)
         session_error_response = parse_session_message(e, request_id, session_id_str, json=False)
-        response = JsonResponse(session_error_response, status=200)  # 200 for JSON-RPC errors
+        session_error_response = cast("dict[str, Any]", session_error_response)
+        response = RawJsonResponse(session_error_response, status=200)  # 200 for JSON-RPC errors
     finally:
         if operation_registered:
             session.register_operation_done()

--- a/aqueduct/gateway/views/models.py
+++ b/aqueduct/gateway/views/models.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from asgiref.sync import sync_to_async
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
@@ -11,6 +10,7 @@ from gateway.config import get_router_config
 from management.models import Request, Token
 
 from .decorators import log_request, token_authenticated, tos_accepted
+from .utils import RawJsonResponse
 
 MODEL_CREATION_TIMESTAMP = int(timezone.now().timestamp())
 
@@ -22,12 +22,12 @@ MODEL_CREATION_TIMESTAMP = int(timezone.now().timestamp())
 @log_request
 async def models(
     request: ASGIRequest, token: Token, request_log: Request, *args: Any, **kwargs: Any
-) -> JsonResponse:
+) -> RawJsonResponse:
     router_config = get_router_config()
     model_list: list[dict[str, Any]] = router_config["model_list"]
     excluded_models = set(await sync_to_async(token.model_exclusion_list)())
 
-    return JsonResponse(
+    return RawJsonResponse(
         data={
             "data": [
                 {

--- a/aqueduct/gateway/views/responses.py
+++ b/aqueduct/gateway/views/responses.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from openai import AsyncStream
@@ -25,6 +25,7 @@ from .decorators import (
 )
 from .errors import error_response
 from .utils import (
+    RawJsonResponse,
     ResponseRegistrationWrapper,
     _get_token_usage,
     _openai_stream,
@@ -53,7 +54,7 @@ async def create_response(
     token: Token,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | StreamingHttpResponse:
     """Handler for POST /v1/responses - Creates a new response via OpenAI's responses API
 
     This endpoint forwards requests to the OpenAI responses API, handling both streaming
@@ -80,7 +81,7 @@ async def create_response(
         register_response_in_cache(resp.id, model=model, email=token.user.email)
         data = resp.model_dump(exclude_none=True, exclude_unset=True)
         request_log.token_usage = _get_token_usage(data)
-        return JsonResponse(data=data, status=200)
+        return RawJsonResponse(data=data, status=200)
     raise NotImplementedError(f"Completion for response type {type(resp)} is not implemented.")
 
 
@@ -93,26 +94,26 @@ async def create_response(
 @catch_router_exceptions
 async def response(
     request: ASGIRequest, response_id: str, token: Token, *args: Any, **kwargs: Any
-) -> JsonResponse:
+) -> RawJsonResponse:
     """Combined handler for GET and DELETE /v1/responses/{response_id}"""
     response = get_response_from_cache(response_id)
     if response is None:
-        return JsonResponse({"error": "Response not found"}, status=404)
+        return RawJsonResponse({"error": "Response not found"}, status=404)
     model: str = response["model"]
     client, _model_relay = oai_client_from_body(model, request)
 
     if request.method == "GET":
         get_resp = await client.responses.retrieve(response_id=response_id)
         data = get_resp.model_dump(exclude_none=True, exclude_unset=True)
-        return JsonResponse(data=data, status=200)
+        return RawJsonResponse(data=data, status=200)
     if request.method == "DELETE":
         delete_result = await client.responses.delete(response_id=response_id)  # type: ignore[func-returns-value]
         delete_response_from_cache(response_id=response_id)
         if delete_result is None:
             # BUG in openai python sdk: https://github.com/openai/openai-openapi/issues/490
-            return JsonResponse({"deleted": True}, status=200)
+            return RawJsonResponse({"deleted": True}, status=200)
         data = delete_result.model_dump(exclude_none=True, exclude_unset=True)
-        return JsonResponse(data=data, status=200)
+        return RawJsonResponse(data=data, status=200)
     raise AssertionError("Unreachable")
 
 
@@ -125,13 +126,13 @@ async def response(
 @catch_router_exceptions
 async def get_response_input_items(
     request: ASGIRequest, response_id: str, token: Token, *args: Any, **kwargs: Any
-) -> JsonResponse:
+) -> RawJsonResponse:
     """Handler for GET /v1/responses/{response_id}/input_items"""
     response = get_response_from_cache(response_id)
     if response is None:
-        return JsonResponse({"error": "Response not found"}, status=404)
+        return RawJsonResponse({"error": "Response not found"}, status=404)
     model: str = response["model"]
     client, _model_relay = oai_client_from_body(model, request)
     resp = await client.responses.input_items.list(response_id=response_id)
     data = resp.model_dump(exclude_none=True, exclude_unset=True)
-    return JsonResponse(data=data, status=200)
+    return RawJsonResponse(data=data, status=200)

--- a/aqueduct/gateway/views/responses.py
+++ b/aqueduct/gateway/views/responses.py
@@ -75,8 +75,7 @@ async def create_response(
     if isinstance(resp, Response):
         register_response_in_cache(resp.id, model=model, email=token.user.email)
         request_log.token_usage = get_token_usage(resp)
-        data = resp.model_dump(exclude_none=True, exclude_unset=True)
-        return RawJsonResponse(data=data, status=200)
+        return RawJsonResponse(data=resp, status=200)
     raise NotImplementedError(f"Completion for response type {type(resp)} is not implemented.")
 
 
@@ -99,16 +98,14 @@ async def response(
 
     if request.method == "GET":
         get_resp = await client.responses.retrieve(response_id=response_id)
-        data = get_resp.model_dump(exclude_none=True, exclude_unset=True)
-        return RawJsonResponse(data=data, status=200)
+        return RawJsonResponse(data=get_resp, status=200)
     if request.method == "DELETE":
         delete_result = await client.responses.delete(response_id=response_id)  # type: ignore[func-returns-value]
         delete_response_from_cache(response_id=response_id)
         if delete_result is None:
             # BUG in openai python sdk: https://github.com/openai/openai-openapi/issues/490
             return RawJsonResponse({"deleted": True}, status=200)
-        data = delete_result.model_dump(exclude_none=True, exclude_unset=True)
-        return RawJsonResponse(data=data, status=200)
+        return RawJsonResponse(data=delete_result, status=200)
     raise AssertionError("Unreachable")
 
 
@@ -129,5 +126,4 @@ async def get_response_input_items(
     model: str = response["model"]
     client, _model_relay = oai_client_from_body(model, request)
     resp = await client.responses.input_items.list(response_id=response_id)
-    data = resp.model_dump(exclude_none=True, exclude_unset=True)
-    return RawJsonResponse(data=data, status=200)
+    return RawJsonResponse(data=resp, status=200)

--- a/aqueduct/gateway/views/responses.py
+++ b/aqueduct/gateway/views/responses.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from openai import AsyncStream
@@ -26,11 +25,10 @@ from .decorators import (
 from .errors import error_response
 from .utils import (
     RawJsonResponse,
-    ResponseRegistrationWrapper,
-    _get_token_usage,
-    _openai_stream,
+    RawStreamingResponse,
     delete_response_from_cache,
     get_response_from_cache,
+    get_token_usage,
     oai_client_from_body,
     register_response_in_cache,
 )
@@ -54,7 +52,7 @@ async def create_response(
     token: Token,
     *args: Any,
     **kwargs: Any,
-) -> RawJsonResponse | StreamingHttpResponse:
+) -> RawJsonResponse | RawStreamingResponse:
     """Handler for POST /v1/responses - Creates a new response via OpenAI's responses API
 
     This endpoint forwards requests to the OpenAI responses API, handling both streaming
@@ -69,18 +67,17 @@ async def create_response(
     resp: Response | AsyncStream[Response] = await client.responses.create(**pydantic_model)
 
     if isinstance(resp, AsyncStream):
-        return StreamingHttpResponse(
-            streaming_content=ResponseRegistrationWrapper(
-                streaming_content=_openai_stream(stream=resp, request_log=request_log),
-                model=model,
-                email=token.user.email,
-            ),
-            content_type="text/event-stream",
-        )
+        # TODO: register_response(resp, model=model, email=token.user.email)
+        return RawStreamingResponse(streaming_content=resp, request_log=request_log)
+        # The original response.streaming_content:
+        #     ResponseRegistrationWrapper
+        #       ->  streaming_content=_openai_stream(stream=resp, request_log=request_log),
+        #       ->  model=model, email=token.user.email
+        #
     if isinstance(resp, Response):
         register_response_in_cache(resp.id, model=model, email=token.user.email)
         data = resp.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = _get_token_usage(data)
+        request_log.token_usage = get_token_usage(data)
         return RawJsonResponse(data=data, status=200)
     raise NotImplementedError(f"Completion for response type {type(resp)} is not implemented.")
 

--- a/aqueduct/gateway/views/responses.py
+++ b/aqueduct/gateway/views/responses.py
@@ -5,7 +5,7 @@ from django.core.handlers.asgi import ASGIRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from openai import AsyncStream
-from openai.types.responses import Response
+from openai.types.responses import Response, ResponseStreamEvent
 from pydantic import TypeAdapter
 
 from management.models import Request, Token
@@ -26,6 +26,7 @@ from .errors import error_response
 from .utils import (
     RawJsonResponse,
     RawStreamingResponse,
+    ResponseRegistrationWrapper,
     delete_response_from_cache,
     get_response_from_cache,
     get_token_usage,
@@ -64,20 +65,17 @@ async def create_response(
     client, model_relay = oai_client_from_body(model, request)
     pydantic_model["model"] = model_relay
 
-    resp: Response | AsyncStream[Response] = await client.responses.create(**pydantic_model)
+    resp: Response | AsyncStream[ResponseStreamEvent] = await client.responses.create(
+        **pydantic_model
+    )
 
     if isinstance(resp, AsyncStream):
-        # TODO: register_response(resp, model=model, email=token.user.email)
-        return RawStreamingResponse(streaming_content=resp, request_log=request_log)
-        # The original response.streaming_content:
-        #     ResponseRegistrationWrapper
-        #       ->  streaming_content=_openai_stream(stream=resp, request_log=request_log),
-        #       ->  model=model, email=token.user.email
-        #
+        registered_resp = ResponseRegistrationWrapper(resp, model=model, email=token.user.email)
+        return RawStreamingResponse(streaming_content=registered_resp, request_log=request_log)
     if isinstance(resp, Response):
         register_response_in_cache(resp.id, model=model, email=token.user.email)
+        request_log.token_usage = get_token_usage(resp)
         data = resp.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = get_token_usage(data)
         return RawJsonResponse(data=data, status=200)
     raise NotImplementedError(f"Completion for response type {type(resp)} is not implemented.")
 

--- a/aqueduct/gateway/views/transcriptions.py
+++ b/aqueduct/gateway/views/transcriptions.py
@@ -60,9 +60,8 @@ async def transcriptions(
             openai.types.audio.transcription_verbose.TranscriptionVerbose,
         ),
     ):
-        data = transcription.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = get_token_usage(data)
-        return RawJsonResponse(data=data, status=200)
+        request_log.token_usage = get_token_usage(transcription)
+        return RawJsonResponse(data=transcription, status=200)
     if isinstance(transcription, str):
         # Text-based formats (VTT, SRT, text) return plain strings
         return HttpResponse(

--- a/aqueduct/gateway/views/transcriptions.py
+++ b/aqueduct/gateway/views/transcriptions.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from openai.types.audio.transcription_create_params import (
@@ -22,7 +22,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import RawJsonResponse, _get_token_usage, _openai_stream, oai_client_from_body
+from .utils import RawJsonResponse, RawStreamingResponse, get_token_usage, oai_client_from_body
 
 
 class TranscriptionCreateParams(RootModel):  # type: ignore[type-arg]
@@ -47,7 +47,7 @@ async def transcriptions(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> RawJsonResponse | HttpResponse | StreamingHttpResponse:
+) -> RawJsonResponse | HttpResponse | RawStreamingResponse:
     client, model_relay = oai_client_from_body(pydantic_model.get("model"), request)
     pydantic_model["model"] = model_relay
 
@@ -61,7 +61,7 @@ async def transcriptions(
         ),
     ):
         data = transcription.model_dump(exclude_none=True, exclude_unset=True)
-        request_log.token_usage = _get_token_usage(data)
+        request_log.token_usage = get_token_usage(data)
         return RawJsonResponse(data=data, status=200)
     if isinstance(transcription, str):
         # Text-based formats (VTT, SRT, text) return plain strings
@@ -71,8 +71,5 @@ async def transcriptions(
             status=200,
         )
     if isinstance(transcription, openai.AsyncStream):
-        return StreamingHttpResponse(
-            streaming_content=_openai_stream(stream=transcription, request_log=request_log),
-            content_type="text/event-stream",
-        )
+        return RawStreamingResponse(streaming_content=transcription, request_log=request_log)
     raise RuntimeError(f"Received unexpected response type: {type(transcription)}")

--- a/aqueduct/gateway/views/transcriptions.py
+++ b/aqueduct/gateway/views/transcriptions.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import openai
 from django.core.handlers.asgi import ASGIRequest
-from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from openai.types.audio.transcription_create_params import (
@@ -22,7 +22,7 @@ from .decorators import (
     token_authenticated,
     tos_accepted,
 )
-from .utils import _get_token_usage, _openai_stream, oai_client_from_body
+from .utils import RawJsonResponse, _get_token_usage, _openai_stream, oai_client_from_body
 
 
 class TranscriptionCreateParams(RootModel):  # type: ignore[type-arg]
@@ -47,7 +47,7 @@ async def transcriptions(
     request_log: Request,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse | HttpResponse | StreamingHttpResponse:
+) -> RawJsonResponse | HttpResponse | StreamingHttpResponse:
     client, model_relay = oai_client_from_body(pydantic_model.get("model"), request)
     pydantic_model["model"] = model_relay
 
@@ -62,7 +62,7 @@ async def transcriptions(
     ):
         data = transcription.model_dump(exclude_none=True, exclude_unset=True)
         request_log.token_usage = _get_token_usage(data)
-        return JsonResponse(data=data, status=200)
+        return RawJsonResponse(data=data, status=200)
     if isinstance(transcription, str):
         # Text-based formats (VTT, SRT, text) return plain strings
         return HttpResponse(

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, AsyncIterator, Generator
 from contextlib import contextmanager
 from typing import Any
 
@@ -11,14 +11,42 @@ import openai
 from django.conf import settings
 from django.core.cache import cache, caches
 from django.core.handlers.asgi import ASGIRequest
-from litellm import TextCompletionStreamWrapper
-from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
-from openai import AsyncStream
+from pydantic import BaseModel
 
 from gateway.config import get_openai_client, get_router
 from management.models import Request, Usage
 
 log = logging.getLogger("aqueduct")
+
+
+class RawJsonResponse:
+    """A wrapper for data that can be turned into a JSONResponse."""
+
+    def __init__(self, data: dict[str, Any], **kwargs: Any) -> None:
+        if not isinstance(data, dict):
+            raise TypeError("RawJsonResponse data has to be a dict")
+
+        self.data = data
+        self.kwargs = kwargs
+
+
+class RawStreamingResponse:
+    """A wrapper for streaming data that can be turned into a StreamingHttpResponse."""
+
+    def __init__(
+        self,
+        stream: AsyncIterator[Any],
+        request_log: Request,
+        content_type: str = "text/event-stream",
+        **kwargs: Any,
+    ) -> None:
+        if not isinstance(stream, AsyncIterator):
+            raise TypeError("RawStreamResponse stream has to be async iterable")
+
+        self.stream = stream
+        self.request_log = request_log
+        self.content_type = content_type
+        self.kwargs = kwargs
 
 
 def _get_token_usage(content: bytes | dict[str, Any]) -> Usage:
@@ -54,8 +82,7 @@ def _get_token_usage(content: bytes | dict[str, Any]) -> Usage:
 
 
 def _openai_stream(
-    stream: CustomStreamWrapper | TextCompletionStreamWrapper | AsyncStream[Any],
-    request_log: Request,
+    stream: AsyncIterator[BaseModel], request_log: Request
 ) -> AsyncGenerator[str, None]:
     start_time = time.monotonic()
 

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -49,9 +49,8 @@ class RawStreamingResponse:
     def __init__(
         self,
         streaming_content: AsyncIterator[Any],
-        request_log: Request,  # TODO: for mcp requests, there's no request log!
-        transforms: list[Callable[[ModelResponseStream], ModelResponseStream]]
-        | None = None,  # TODO: fix types
+        request_log: Request | None,  # TODO: for mcp requests, there's no request log!
+        transforms: list[Callable[[ModelResponseStream], ModelResponseStream]] | None = None,
         **kwargs: Any,
     ) -> None:
         if not isinstance(streaming_content, AsyncIterator):

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -32,12 +32,12 @@ class RawJsonResponse:
 
         self.content = data
         self.kwargs = kwargs or {}
+        self.content_type = self.kwargs.setdefault("content_type", "application/json")
+        # Just to be on the safe side, make header keys case-insensitive:
+        self.headers = ResponseHeaders(self.kwargs.setdefault("headers", {}))
         # The following mimics the BaseHttpResponse behaviour (argument called "status"
         # is assigned to the "status_code" attribute)
         self.status_code = self.kwargs.get("status", 200)
-        # Just to be on the safe side, make header keys case-insensitive:
-        self.headers = ResponseHeaders(self.kwargs.get("headers", {}))
-        self.content_type = self.kwargs.get("content_type", "application/json")
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} status_code={self.status_code}>"
@@ -60,12 +60,12 @@ class RawStreamingResponse:
         self.request_log = request_log
         self.transforms = transforms or []
         self.kwargs = kwargs or {}
+        self.content_type = self.kwargs.setdefault("content_type", "text/event-stream")
+        # Just to be on the safe side, make header keys case-insensitive:
+        self.headers = ResponseHeaders(self.kwargs.setdefault("headers", {}))
         # The following mimics the BaseHttpResponse behaviour (argument called "status"
         # is assigned to the "status_code" attribute)
         self.status_code = self.kwargs.get("status", 200)
-        # Just to be on the safe side, make header keys case-insensitive:
-        self.headers = ResponseHeaders(self.kwargs.get("headers", {}))
-        self.content_type = self.kwargs.get("content_type", "text/event-stream")
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} status_code={self.status_code}>"

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -22,34 +22,31 @@ log = logging.getLogger("aqueduct")
 class RawJsonResponse:
     """A wrapper for data that can be turned into a JSONResponse."""
 
-    def __init__(self, data: dict[str, Any], status_code: int = 200, **kwargs: Any) -> None:
+    def __init__(self, data: dict[str, Any], **kwargs: Any) -> None:
         if not isinstance(data, dict):
             raise TypeError("RawJsonResponse data has to be a dict")
 
         self.content = data
-        self.status_code = status_code
-        self.kwargs = kwargs
+        self.kwargs = kwargs or {}
+        # The following mimics the JsonResponse behaviour (argument called "status"
+        # is assigned to the "status_code" attribute)
+        self.status_code = self.kwargs.get("status", 200)
+        self.headers = self.kwargs.get("headers", {})
 
 
 class RawStreamingResponse:
     """A wrapper for streaming data that can be turned into a StreamingHttpResponse."""
 
     def __init__(
-        self,
-        streaming_content: AsyncIterator[Any],
-        request_log: Request,
-        content_type: str = "text/event-stream",
-        status_code: int = 200,
-        **kwargs: Any,
+        self, streaming_content: AsyncIterator[Any], request_log: Request, **kwargs: Any
     ) -> None:
         if not isinstance(streaming_content, AsyncIterator):
             raise TypeError("RawStreamResponse streaming_content has to be async iterable")
 
         self.streaming_content = streaming_content
         self.request_log = request_log
-        self.content_type = content_type
-        self.status_code = status_code
-        self.kwargs = kwargs
+        self.kwargs = kwargs or {}
+        self.content_type = self.kwargs.get("content_type", "text/event-stream")
 
 
 def _get_token_usage(content: bytes | dict[str, Any]) -> Usage:

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -11,8 +11,14 @@ from django.conf import settings
 from django.core.cache import cache, caches
 from django.core.handlers.asgi import ASGIRequest
 from django.http.response import ResponseHeaders
-from litellm.types.utils import ModelResponseStream
+from litellm.types.utils import (
+    EmbeddingResponse,
+    ModelResponse,
+    ModelResponseStream,
+    TextCompletionResponse,
+)
 from litellm.types.utils import Usage as UsageModel
+from mcp.types import JSONRPCMessage
 from openai import AsyncStream
 from openai.types.responses import ResponseCreatedEvent, ResponseStreamEvent
 from pydantic import BaseModel
@@ -22,15 +28,15 @@ from management.models import Request, Usage
 
 log = logging.getLogger("aqueduct")
 
-T = TypeVar("T", bound=ModelResponseStream | dict[str, Any])
+T = TypeVar("T", bound=ModelResponseStream | JSONRPCMessage)
 
 
 class RawJsonResponse:
     """A wrapper for data that can be turned into a JSONResponse."""
 
-    def __init__(self, data: dict[str, Any], **kwargs: Any) -> None:
-        if not isinstance(data, dict):
-            raise TypeError("RawJsonResponse data has to be a dict")
+    def __init__(self, data: dict[str, Any] | BaseModel, **kwargs: Any) -> None:
+        if not isinstance(data, (dict, BaseModel)):
+            raise TypeError("RawJsonResponse data has to be a dict or a pydantic BaseModel")
 
         self.content = data
         self.kwargs = kwargs or {}
@@ -81,12 +87,14 @@ def get_token_usage(data: dict[str, Any] | BaseModel) -> Usage:
     i.e. set to 0.
 
     Args:
-        data: The raw response content (or content's chunk for streaming responses)
-          as a dict or BaseModel subclass (for RawStreamingResponses).
+        data: The raw response content (or content's chunk for streaming responses),
+          expected to be a dict or BaseModel subclass.
     Returns:
         The :class:`Usage` object with the used input and output token counts.
     """
-    if isinstance(data, (dict, ModelResponseStream)):
+    if isinstance(
+        data, (dict, ModelResponse, ModelResponseStream, EmbeddingResponse, TextCompletionResponse)
+    ):
         # LiteLLM models implement `.get()` method, but the OpenAI ones - don't.
         usage = data.get("usage")
         if isinstance(usage, (dict, UsageModel)):
@@ -99,8 +107,11 @@ def get_token_usage(data: dict[str, Any] | BaseModel) -> Usage:
         if not usage and hasattr(data, "response"):
             usage = getattr(data.response, "usage", None)
         if usage:
-            input_tokens = usage.input_tokens
-            output_tokens = usage.output_tokens
+            try:
+                input_tokens = usage.input_tokens
+                output_tokens = usage.output_tokens
+            except AttributeError:
+                input_tokens = output_tokens = 0
             return Usage(input_tokens=input_tokens, output_tokens=output_tokens)
 
     return Usage(input_tokens=0, output_tokens=0)

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -11,6 +11,7 @@ import openai
 from django.conf import settings
 from django.core.cache import cache, caches
 from django.core.handlers.asgi import ASGIRequest
+from django.http.response import ResponseHeaders
 from pydantic import BaseModel
 
 from gateway.config import get_openai_client, get_router
@@ -28,10 +29,15 @@ class RawJsonResponse:
 
         self.content = data
         self.kwargs = kwargs or {}
-        # The following mimics the JsonResponse behaviour (argument called "status"
+        # The following mimics the BaseHttpResponse behaviour (argument called "status"
         # is assigned to the "status_code" attribute)
         self.status_code = self.kwargs.get("status", 200)
-        self.headers = self.kwargs.get("headers", {})
+        # Just to be on the safe side, make header keys case-insensitive:
+        self.headers = ResponseHeaders(self.kwargs.get("headers", {}))
+        self.content_type = self.kwargs.get("content_type", "application/json")
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} status_code={self.status_code}"
 
 
 class RawStreamingResponse:
@@ -46,7 +52,15 @@ class RawStreamingResponse:
         self.streaming_content = streaming_content
         self.request_log = request_log
         self.kwargs = kwargs or {}
+        # The following mimics the BaseHttpResponse behaviour (argument called "status"
+        # is assigned to the "status_code" attribute)
+        self.status_code = self.kwargs.get("status", 200)
+        # Just to be on the safe side, make header keys case-insensitive:
+        self.headers = ResponseHeaders(self.kwargs.get("headers", {}))
         self.content_type = self.kwargs.get("content_type", "text/event-stream")
+
+    def __str__(self) -> str:
+        return f"<{self.__class__.__name__} status_code={self.status_code}"
 
 
 def _get_token_usage(content: bytes | dict[str, Any]) -> Usage:

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -49,7 +49,7 @@ class RawStreamingResponse:
     def __init__(
         self,
         streaming_content: AsyncIterator[Any],
-        request_log: Request | None,  # TODO: for mcp requests, there's no request log!
+        request_log: Request | None,
         transforms: list[Callable[[ModelResponseStream], ModelResponseStream]] | None = None,
         **kwargs: Any,
     ) -> None:

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -86,19 +86,23 @@ def get_token_usage(data: dict[str, Any] | BaseModel) -> Usage:
     Returns:
         The :class:`Usage` object with the used input and output token counts.
     """
-    # Handle responses API format (top-level usage or in response field)
     if isinstance(data, (dict, ModelResponseStream)):
         # LiteLLM models implement `.get()` method, but the OpenAI ones - don't.
         usage = data.get("usage")
+        if isinstance(usage, (dict, UsageModel)):
+            input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens", 0)
+            output_tokens = usage.get("completion_tokens") or usage.get("output_tokens", 0)
+            return Usage(input_tokens=input_tokens, output_tokens=output_tokens)
     else:
-        data = data.model_dump(exclude_none=True, exclude_unset=True)
-        usage = data.get("usage")
-    if not usage and "response" in data:
-        usage = data["response"].get("usage")
-    if isinstance(usage, (dict, UsageModel)):
-        input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens", 0)
-        output_tokens = usage.get("completion_tokens") or usage.get("output_tokens", 0)
-        return Usage(input_tokens=input_tokens, output_tokens=output_tokens)
+        # Handle responses API format (top-level usage or in response field)
+        usage = getattr(data, "usage", None)
+        if not usage and hasattr(data, "response"):
+            usage = getattr(data.response, "usage", None)
+        if usage:
+            input_tokens = usage.input_tokens
+            output_tokens = usage.output_tokens
+            return Usage(input_tokens=input_tokens, output_tokens=output_tokens)
+
     return Usage(input_tokens=0, output_tokens=0)
 
 

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Callable, Generator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, TypeVar
 
 import httpx
 import litellm
@@ -21,6 +21,8 @@ from gateway.config import get_openai_client, get_router
 from management.models import Request, Usage
 
 log = logging.getLogger("aqueduct")
+
+T = TypeVar("T", bound=ModelResponseStream | dict[str, Any])
 
 
 class RawJsonResponse:
@@ -50,7 +52,7 @@ class RawStreamingResponse:
         self,
         streaming_content: AsyncIterator[Any],
         request_log: Request | None,
-        transforms: list[Callable[[ModelResponseStream], ModelResponseStream]] | None = None,
+        transforms: list[Callable[[T], T]] | None = None,
         **kwargs: Any,
     ) -> None:
         if not isinstance(streaming_content, AsyncIterator):

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -1,7 +1,6 @@
-import json
 import logging
 import time
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Generator
+from collections.abc import AsyncIterator, Callable, Generator
 from contextlib import contextmanager
 from typing import Any
 
@@ -14,6 +13,9 @@ from django.core.handlers.asgi import ASGIRequest
 from django.http.response import ResponseHeaders
 from litellm.types.utils import ModelResponseStream
 from litellm.types.utils import Usage as UsageModel
+from openai import AsyncStream
+from openai.types.responses import ResponseCreatedEvent, ResponseStreamEvent
+from pydantic import BaseModel
 
 from gateway.config import get_openai_client, get_router
 from management.models import Request, Usage
@@ -70,7 +72,7 @@ class RawStreamingResponse:
         return f"<{self.__class__.__name__} status_code={self.status_code}>"
 
 
-def get_token_usage(data: dict[str, Any] | ModelResponseStream) -> Usage:
+def get_token_usage(data: dict[str, Any] | BaseModel) -> Usage:
     """Retrieves token usage information from the raw response content.
 
     Note that if the response data does not match the expected format, or does
@@ -79,14 +81,19 @@ def get_token_usage(data: dict[str, Any] | ModelResponseStream) -> Usage:
 
     Args:
         data: The raw response content (or content's chunk for streaming responses)
-          as a dict or ModelResponseStream (for RawStreamingResponses).
+          as a dict or BaseModel subclass (for RawStreamingResponses).
     Returns:
         The :class:`Usage` object with the used input and output token counts.
     """
     # Handle responses API format (top-level usage or in response field)
-    usage = data.get("usage")
+    if isinstance(data, (dict, ModelResponseStream)):
+        # LiteLLM models implement `.get()` method, but the OpenAI ones - don't.
+        usage = data.get("usage")
+    else:
+        data = data.model_dump(exclude_none=True, exclude_unset=True)
+        usage = data.get("usage")
     if not usage and "response" in data:
-        usage = data["response"].get("usage", None)
+        usage = data["response"].get("usage")
     if isinstance(usage, (dict, UsageModel)):
         input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens", 0)
         output_tokens = usage.get("completion_tokens") or usage.get("output_tokens", 0)
@@ -165,7 +172,7 @@ def oai_client_from_body(model: str, request: ASGIRequest) -> tuple[openai.Async
 class ResponseRegistrationWrapper:
     """Wraps streaming content to register response on first chunk."""
 
-    def __init__(self, streaming_content: AsyncGenerator[str, None], model: str, email: str):
+    def __init__(self, streaming_content: AsyncStream[ResponseStreamEvent], model: str, email: str):
         self.streaming_content = streaming_content
         self.model_name = model
         self.user_email = email
@@ -174,30 +181,18 @@ class ResponseRegistrationWrapper:
     def __aiter__(self) -> "ResponseRegistrationWrapper":
         return self
 
-    async def __anext__(self) -> str:
-        chunk: str = await self.streaming_content.__anext__()
-        if not self._registered and chunk:
-            response_id = self.extract_response_id_from_chunk(chunk)
+    async def __anext__(self) -> ResponseStreamEvent:
+        chunk: ResponseStreamEvent = await self.streaming_content.__anext__()
+        if (
+            not self._registered
+            and isinstance(chunk, ResponseCreatedEvent)
+            and chunk.type == "response.created"
+        ):
+            response_id: str | None = chunk.response.id
             if response_id:
                 register_response_in_cache(response_id, self.model_name, self.user_email)
                 self._registered = True
         return chunk
-
-    @staticmethod
-    def extract_response_id_from_chunk(chunk: str) -> str | None:
-        """Extract response ID from SSE chunk containing 'response.created' event."""
-        try:
-            # Parse SSE format: "data: {json}"
-            for line in chunk.split("\n"):
-                if line.startswith("data: ") and "response.created" in line:
-                    json_data: dict[str, Any] = json.loads(line.removeprefix("data: "))
-                    if json_data.get("type") == "response.created":
-                        response_data: dict[str, Any] = json_data.get("response", {})
-                        response_id: str | None = response_data.get("id")
-                        return response_id
-        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
-            return None
-        return None
 
 
 def register_response_in_cache(response_id: str | None, model: str, email: str) -> None:

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from collections.abc import AsyncGenerator, AsyncIterator, Generator
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Generator
 from contextlib import contextmanager
 from typing import Any
 
@@ -12,7 +12,8 @@ from django.conf import settings
 from django.core.cache import cache, caches
 from django.core.handlers.asgi import ASGIRequest
 from django.http.response import ResponseHeaders
-from pydantic import BaseModel
+from litellm.types.utils import ModelResponseStream
+from litellm.types.utils import Usage as UsageModel
 
 from gateway.config import get_openai_client, get_router
 from management.models import Request, Usage
@@ -37,20 +38,26 @@ class RawJsonResponse:
         self.content_type = self.kwargs.get("content_type", "application/json")
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} status_code={self.status_code}"
+        return f"<{self.__class__.__name__} status_code={self.status_code}>"
 
 
 class RawStreamingResponse:
     """A wrapper for streaming data that can be turned into a StreamingHttpResponse."""
 
     def __init__(
-        self, streaming_content: AsyncIterator[Any], request_log: Request, **kwargs: Any
+        self,
+        streaming_content: AsyncIterator[Any],
+        request_log: Request,  # TODO: for mcp requests, there's no request log!
+        transforms: list[Callable[[ModelResponseStream], ModelResponseStream]]
+        | None = None,  # TODO: fix types
+        **kwargs: Any,
     ) -> None:
         if not isinstance(streaming_content, AsyncIterator):
             raise TypeError("RawStreamResponse streaming_content has to be async iterable")
 
         self.streaming_content = streaming_content
         self.request_log = request_log
+        self.transforms = transforms or []
         self.kwargs = kwargs or {}
         # The following mimics the BaseHttpResponse behaviour (argument called "status"
         # is assigned to the "status_code" attribute)
@@ -59,72 +66,32 @@ class RawStreamingResponse:
         self.headers = ResponseHeaders(self.kwargs.get("headers", {}))
         self.content_type = self.kwargs.get("content_type", "text/event-stream")
 
-    def __str__(self) -> str:
-        return f"<{self.__class__.__name__} status_code={self.status_code}"
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} status_code={self.status_code}>"
 
 
-def _get_token_usage(content: bytes | dict[str, Any]) -> Usage:
-    """Retrieves token usage information from the response content.
+def get_token_usage(data: dict[str, Any] | ModelResponseStream) -> Usage:
+    """Retrieves token usage information from the raw response content.
 
     Note that if the response data does not match the expected format, or does
     not contain the usage information, the returned token usage will be wrong,
     i.e. set to 0.
 
     Args:
-        content: The response content, either as a dict or as bytes.
+        data: The raw response content (or content's chunk for streaming responses)
+          as a dict or ModelResponseStream (for RawStreamingResponses).
     Returns:
         The :class:`Usage` object with the used input and output token counts.
     """
-
-    if isinstance(content, dict):
-        data = content
-    else:
-        try:
-            data = json.loads(content)
-        except json.JSONDecodeError:
-            return Usage(input_tokens=0, output_tokens=0)
-
     # Handle responses API format (top-level usage or in response field)
-    usage_dict = data.get("usage", None)
-    if not usage_dict and "response" in data:
-        usage_dict = data["response"].get("usage", None)
-    if isinstance(usage_dict, dict):
-        input_tokens = usage_dict.get("prompt_tokens") or usage_dict.get("input_tokens", 0)
-        output_tokens = usage_dict.get("completion_tokens") or usage_dict.get("output_tokens", 0)
+    usage = data.get("usage")
+    if not usage and "response" in data:
+        usage = data["response"].get("usage", None)
+    if isinstance(usage, (dict, UsageModel)):
+        input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens", 0)
+        output_tokens = usage.get("completion_tokens") or usage.get("output_tokens", 0)
         return Usage(input_tokens=input_tokens, output_tokens=output_tokens)
     return Usage(input_tokens=0, output_tokens=0)
-
-
-def _openai_stream(
-    stream: AsyncIterator[BaseModel], request_log: Request
-) -> AsyncGenerator[str, None]:
-    start_time = time.monotonic()
-
-    async def _stream() -> AsyncGenerator[str, None]:
-        token_usage = Usage(0, 0)
-        async for chunk in stream:
-            chunk_str = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
-
-            # Extract token usage from this chunk
-            chunk_usage = _get_token_usage(chunk_str.encode("utf-8"))
-
-            # Only update if we got actual usage data (non-zero tokens)
-            if chunk_usage.input_tokens > 0 or chunk_usage.output_tokens > 0:
-                token_usage = chunk_usage
-
-            try:
-                yield f"data: {chunk_str}\n\n"
-            except Exception as e:
-                yield f"data: {e!s}\n\n"
-
-        end_time = time.monotonic()
-        request_log.token_usage = token_usage
-        request_log.response_time_ms = int((end_time - start_time) * 1000)
-        await request_log.asave()
-        # Streaming is done, yield the [DONE] chunk
-        yield "data: [DONE]\n\n"
-
-    return _stream()
 
 
 @contextmanager

--- a/aqueduct/gateway/views/utils.py
+++ b/aqueduct/gateway/views/utils.py
@@ -22,11 +22,12 @@ log = logging.getLogger("aqueduct")
 class RawJsonResponse:
     """A wrapper for data that can be turned into a JSONResponse."""
 
-    def __init__(self, data: dict[str, Any], **kwargs: Any) -> None:
+    def __init__(self, data: dict[str, Any], status_code: int = 200, **kwargs: Any) -> None:
         if not isinstance(data, dict):
             raise TypeError("RawJsonResponse data has to be a dict")
 
-        self.data = data
+        self.content = data
+        self.status_code = status_code
         self.kwargs = kwargs
 
 
@@ -35,17 +36,19 @@ class RawStreamingResponse:
 
     def __init__(
         self,
-        stream: AsyncIterator[Any],
+        streaming_content: AsyncIterator[Any],
         request_log: Request,
         content_type: str = "text/event-stream",
+        status_code: int = 200,
         **kwargs: Any,
     ) -> None:
-        if not isinstance(stream, AsyncIterator):
-            raise TypeError("RawStreamResponse stream has to be async iterable")
+        if not isinstance(streaming_content, AsyncIterator):
+            raise TypeError("RawStreamResponse streaming_content has to be async iterable")
 
-        self.stream = stream
+        self.streaming_content = streaming_content
         self.request_log = request_log
         self.content_type = content_type
+        self.status_code = status_code
         self.kwargs = kwargs
 
 

--- a/aqueduct/gateway/views/vector_store_file_batches.py
+++ b/aqueduct/gateway/views/vector_store_file_batches.py
@@ -188,9 +188,7 @@ async def vector_store_file_batches(
         return error_response("File limit exceeded", status=403)
 
     # Return upstream response directly (IDs already match)
-    response_data = remote_batch.model_dump(mode="json")
-
-    return RawJsonResponse(response_data, status=200)
+    return RawJsonResponse(remote_batch, status=200)
 
 
 @csrf_exempt
@@ -252,9 +250,7 @@ async def vector_store_file_batch(
         )
 
     # Return upstream response directly (IDs already match)
-    response_data = remote_batch.model_dump(mode="json")
-
-    return RawJsonResponse(response_data, status=200)
+    return RawJsonResponse(remote_batch, status=200)
 
 
 @csrf_exempt
@@ -317,9 +313,7 @@ async def vector_store_file_batch_cancel(
     )
 
     # Return upstream response directly (IDs already match)
-    response_data = remote_batch.model_dump(mode="json")
-
-    return RawJsonResponse(response_data, status=200)
+    return RawJsonResponse(remote_batch, status=200)
 
 
 @csrf_exempt
@@ -370,11 +364,4 @@ async def vector_store_file_batch_files(
 
     # Return upstream response directly (IDs already match)
     remote_files = remote_files_response.data if hasattr(remote_files_response, "data") else []
-    response_files = []
-    for remote_file in remote_files:
-        file_data = remote_file.model_dump(mode="json")
-        response_files.append(file_data)
-
-    return RawJsonResponse(
-        {"object": "list", "data": response_files, "has_more": False}, status=200
-    )
+    return RawJsonResponse({"object": "list", "data": remote_files, "has_more": False}, status=200)

--- a/aqueduct/gateway/views/vector_store_file_batches.py
+++ b/aqueduct/gateway/views/vector_store_file_batches.py
@@ -5,7 +5,6 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
 from django.db import transaction
-from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
@@ -31,6 +30,7 @@ from .decorators import (
     tos_accepted,
 )
 from .errors import error_response
+from .utils import RawJsonResponse
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ async def vector_store_file_batches(
     pydantic_model: FileBatchCreateParams,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     POST /v1/vector_stores/{vector_store_id}/file_batches - Create file batch
     """
@@ -190,7 +190,7 @@ async def vector_store_file_batches(
     # Return upstream response directly (IDs already match)
     response_data = remote_batch.model_dump(mode="json")
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -206,7 +206,7 @@ async def vector_store_file_batch(
     batch_id: str,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /v1/vector_stores/{vector_store_id}/file_batches/{batch_id} - Retrieve batch
     """
@@ -254,7 +254,7 @@ async def vector_store_file_batch(
     # Return upstream response directly (IDs already match)
     response_data = remote_batch.model_dump(mode="json")
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -270,7 +270,7 @@ async def vector_store_file_batch_cancel(
     batch_id: str,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     POST /v1/vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel - Cancel batch
     """
@@ -319,7 +319,7 @@ async def vector_store_file_batch_cancel(
     # Return upstream response directly (IDs already match)
     response_data = remote_batch.model_dump(mode="json")
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -335,7 +335,7 @@ async def vector_store_file_batch_files(
     batch_id: str,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /v1/vector_stores/{vector_store_id}/file_batches/{batch_id}/files - List files in batch
     """
@@ -375,4 +375,6 @@ async def vector_store_file_batch_files(
         file_data = remote_file.model_dump(mode="json")
         response_files.append(file_data)
 
-    return JsonResponse({"object": "list", "data": response_files, "has_more": False}, status=200)
+    return RawJsonResponse(
+        {"object": "list", "data": response_files, "has_more": False}, status=200
+    )

--- a/aqueduct/gateway/views/vector_store_files.py
+++ b/aqueduct/gateway/views/vector_store_files.py
@@ -5,7 +5,6 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
 from django.db import transaction
-from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods
@@ -24,6 +23,7 @@ from .decorators import (
     tos_accepted,
 )
 from .errors import error_response
+from .utils import RawJsonResponse
 
 
 class FileUpdateBody(TypedDict, total=False):
@@ -77,7 +77,7 @@ async def vector_store_files(
     pydantic_model: FileCreateParams | None = None,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /v1/vector_stores/{vector_store_id}/files - List files in vector store
     POST /v1/vector_stores/{vector_store_id}/files - Add file to vector store
@@ -109,7 +109,7 @@ async def vector_store_files(
             file_data = remote_file.model_dump(mode="json")
             response_files.append(file_data)
 
-        return JsonResponse(
+        return RawJsonResponse(
             {"object": "list", "data": response_files, "has_more": False}, status=200
         )
 
@@ -164,7 +164,7 @@ async def vector_store_files(
     # Return upstream response directly (IDs already match)
     response_data = remote_vs_file.model_dump(mode="json")
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -182,7 +182,7 @@ async def vector_store_file(
     pydantic_model: FileUpdateBody | None = None,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /v1/vector_stores/{vector_store_id}/files/{file_id} - Retrieve file
     POST /v1/vector_stores/{vector_store_id}/files/{file_id} - Update file attributes
@@ -222,7 +222,7 @@ async def vector_store_file(
         # Return upstream response directly (IDs already match)
         response_data = remote_vs_file.model_dump(mode="json")
 
-        return JsonResponse(response_data, status=200)
+        return RawJsonResponse(response_data, status=200)
 
     if request.method == "POST":
         # Update file attributes
@@ -240,7 +240,7 @@ async def vector_store_file(
         # Return upstream response directly (IDs already match)
         response_data = remote_vs_file.model_dump(mode="json")
 
-        return JsonResponse(response_data, status=200)
+        return RawJsonResponse(response_data, status=200)
 
     await vs_file_obj.adelete_upstream(client)
 
@@ -250,7 +250,7 @@ async def vector_store_file(
     # Return response with upstream ID
     response_data = {"id": file_id, "object": "vector_store.file.deleted", "deleted": True}
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -266,7 +266,7 @@ async def vector_store_file_content(
     file_id: str,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /v1/vector_stores/{vector_store_id}/files/{file_id}/content - Get file content
     """
@@ -302,4 +302,4 @@ async def vector_store_file_content(
     # FileContentResponse and AsyncPage[FileContentResponse] are both Pydantic models
     response_data = content_response.model_dump()
 
-    return JsonResponse(response_data)
+    return RawJsonResponse(response_data)

--- a/aqueduct/gateway/views/vector_store_files.py
+++ b/aqueduct/gateway/views/vector_store_files.py
@@ -104,13 +104,8 @@ async def vector_store_files(
         remote_files = remote_files_response.data if hasattr(remote_files_response, "data") else []
 
         # Return upstream data directly (IDs already match)
-        response_files = []
-        for remote_file in remote_files:
-            file_data = remote_file.model_dump(mode="json")
-            response_files.append(file_data)
-
         return RawJsonResponse(
-            {"object": "list", "data": response_files, "has_more": False}, status=200
+            {"object": "list", "data": remote_files, "has_more": False}, status=200
         )
 
     # POST /v1/vector_stores/{vector_store_id}/files - Add file to vector store
@@ -162,9 +157,7 @@ async def vector_store_files(
         return error_response(f"Vector store file limit reached ({max_files})", status=403)
 
     # Return upstream response directly (IDs already match)
-    response_data = remote_vs_file.model_dump(mode="json")
-
-    return RawJsonResponse(response_data, status=200)
+    return RawJsonResponse(remote_vs_file, status=200)
 
 
 @csrf_exempt
@@ -220,9 +213,7 @@ async def vector_store_file(
             return error_response("Vector store file not found.", param="file_id", status=404)
 
         # Return upstream response directly (IDs already match)
-        response_data = remote_vs_file.model_dump(mode="json")
-
-        return RawJsonResponse(response_data, status=200)
+        return RawJsonResponse(remote_vs_file, status=200)
 
     if request.method == "POST":
         # Update file attributes
@@ -238,9 +229,7 @@ async def vector_store_file(
         remote_vs_file = await client.vector_stores.files.update(**update_kwargs)
 
         # Return upstream response directly (IDs already match)
-        response_data = remote_vs_file.model_dump(mode="json")
-
-        return RawJsonResponse(response_data, status=200)
+        return RawJsonResponse(remote_vs_file, status=200)
 
     await vs_file_obj.adelete_upstream(client)
 
@@ -300,6 +289,4 @@ async def vector_store_file_content(
     )
 
     # FileContentResponse and AsyncPage[FileContentResponse] are both Pydantic models
-    response_data = content_response.model_dump()
-
-    return RawJsonResponse(response_data)
+    return RawJsonResponse(content_response)

--- a/aqueduct/gateway/views/vector_stores.py
+++ b/aqueduct/gateway/views/vector_stores.py
@@ -3,7 +3,6 @@ from typing import Any
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
 from django.db.models import Count, Q
-from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods, require_POST
@@ -27,6 +26,7 @@ from .decorators import (
     tos_accepted,
 )
 from .errors import error_response
+from .utils import RawJsonResponse
 
 
 @csrf_exempt
@@ -42,7 +42,7 @@ async def vector_stores(
     pydantic_model: VectorStoreCreateParams | None = None,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /v1/vector_stores - List vector stores
     POST /v1/vector_stores - Create vector store
@@ -73,7 +73,7 @@ async def vector_stores(
             )
         )
 
-        return JsonResponse(
+        return RawJsonResponse(
             {
                 "object": "list",
                 "data": [
@@ -153,7 +153,7 @@ async def vector_stores(
     # Return upstream response directly (ID already matches)
     response_data = remote_vs.model_dump(mode="json")
 
-    return JsonResponse(response_data, status=200)
+    return RawJsonResponse(response_data, status=200)
 
 
 @csrf_exempt
@@ -172,7 +172,7 @@ async def vector_store(
     client: AsyncOpenAI | None = None,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     GET /v1/vector_stores/{vector_store_id} - Retrieve vector store
     POST /v1/vector_stores/{vector_store_id} - Modify vector store
@@ -199,7 +199,7 @@ async def vector_store(
         # Return upstream response directly (ID already matches)
         response_data = remote_vs.model_dump(mode="json")
 
-        return JsonResponse(response_data, status=200)
+        return RawJsonResponse(response_data, status=200)
 
     if request.method == "POST":
         # Modify vector store
@@ -229,14 +229,14 @@ async def vector_store(
             # Return upstream response directly (ID already matches)
             response_data = remote_vs.model_dump(mode="json")
 
-            return JsonResponse(response_data, status=200)
+            return RawJsonResponse(response_data, status=200)
 
         # No changes requested, return current state
         remote_vs = await vs_obj.areload_from_upstream(client)
         if not remote_vs:
             return error_response("Vector store not found.", param="vector_store_id", status=404)
         response_data = remote_vs.model_dump(mode="json")
-        return JsonResponse(response_data, status=200)
+        return RawJsonResponse(response_data, status=200)
 
     await vs_obj.adelete_upstream(client)
 
@@ -247,7 +247,7 @@ async def vector_store(
     await vs_obj.adelete()
 
     # Return with upstream ID
-    return JsonResponse(
+    return RawJsonResponse(
         {"id": deleted_id, "object": "vector_store.deleted", "deleted": True}, status=200
     )
 
@@ -267,7 +267,7 @@ async def vector_store_search(
     pydantic_model: VectorStoreSearchParams,
     *args: Any,
     **kwargs: Any,
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     POST /v1/vector_stores/{vector_store_id}/search - Search vector store
     """
@@ -292,4 +292,4 @@ async def vector_store_search(
     # Return upstream response directly (IDs already match)
     results_data = search_results.model_dump(mode="json")
 
-    return JsonResponse(results_data, status=200)
+    return RawJsonResponse(results_data, status=200)

--- a/aqueduct/management/views/test_auth.py
+++ b/aqueduct/management/views/test_auth.py
@@ -10,12 +10,12 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.handlers.asgi import ASGIRequest
 from django.db import transaction
-from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods, require_POST
 
 from gateway.views.decorators import token_authenticated
+from gateway.views.utils import RawJsonResponse
 from management.models import Org, Token, UserProfile
 
 User = get_user_model()
@@ -52,7 +52,7 @@ def _create_db_token() -> tuple[str, str]:
 @csrf_exempt
 @require_POST
 @token_authenticated(token_auth_only=True)
-async def generate_test_token(request: ASGIRequest, *args: Any, **kwargs: Any) -> JsonResponse:
+async def generate_test_token(request: ASGIRequest, *args: Any, **kwargs: Any) -> RawJsonResponse:
     """
     Generate a new `User` + `UserProfile` + `Token` for load testing.
 
@@ -60,17 +60,19 @@ async def generate_test_token(request: ASGIRequest, *args: Any, **kwargs: Any) -
     Only enabled when LOAD_TESTING=True to prevent abuse in production.
     """
     if not getattr(settings, "LOAD_TESTING", False):
-        return JsonResponse(
+        return RawJsonResponse(
             {"error": "Test token generation only available in load-testing mode"},
             status=HTTPStatus.FORBIDDEN,
         )
 
     try:
         token_value, username = await sync_to_async(_create_db_token)()
-        return JsonResponse({"token": token_value, "username": username}, status=HTTPStatus.CREATED)
+        return RawJsonResponse(
+            {"token": token_value, "username": username}, status=HTTPStatus.CREATED
+        )
     except Exception as e:
         log.exception("Failed to generate test token for load testing")
-        return JsonResponse({"error": str(e)}, status=HTTPStatus.INTERNAL_SERVER_ERROR)
+        return RawJsonResponse({"error": str(e)}, status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 @csrf_exempt
@@ -78,7 +80,7 @@ async def generate_test_token(request: ASGIRequest, *args: Any, **kwargs: Any) -
 @token_authenticated(token_auth_only=True)
 async def cleanup_test_token(
     request: ASGIRequest, token: Token, *args: Any, **kwargs: Any
-) -> JsonResponse:
+) -> RawJsonResponse:
     """
     Delete the test `User` and its related objects (particularly: `Token`) after load testing.
 
@@ -86,7 +88,7 @@ async def cleanup_test_token(
     Only enabled when LOAD_TESTING=True to prevent abuse in production.
     """
     if not getattr(settings, "LOAD_TESTING", False):
-        return JsonResponse(
+        return RawJsonResponse(
             {"error": "Test token generation only available in load-testing mode"},
             status=HTTPStatus.FORBIDDEN,
         )
@@ -94,7 +96,7 @@ async def cleanup_test_token(
     username = token.user.username
     if not username.startswith("loadtest-"):
         log.warning("Attempted to delete non-loadtest user via cleanup endpoint: %s", username)
-        return JsonResponse(
+        return RawJsonResponse(
             {"error": "Only loadtest users can be deleted via this endpoint"},
             status=HTTPStatus.FORBIDDEN,
         )
@@ -103,4 +105,4 @@ async def cleanup_test_token(
     await token.user.adelete()
 
     log.info("Cleaned up load test user: %s", username)
-    return JsonResponse({"deleted": True, "username": username})
+    return RawJsonResponse({"deleted": True, "username": username})

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "gateway.middleware.HTTPResponseMiddleware",
     "management.middleware.HealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -73,7 +73,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
-    "gateway.middleware.HTTPResponseMiddleware",
+    "gateway.middleware.HttpResponseMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = (
@@ -445,7 +445,5 @@ LOGGING = {
 
 if TESTING:
     logger = logging.getLogger("aqueduct")
-    logging.disable(logging.ERROR)
-    logger.setLevel(logging.CRITICAL)
-    # logging.disable(logging.NOTSET)
-    # logger.setLevel(logging.DEBUG)
+    logging.disable(logging.NOTSET)
+    logger.setLevel(logging.DEBUG)

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -62,7 +62,6 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "gateway.middleware.HTTPResponseMiddleware",
     "management.middleware.HealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -74,6 +73,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
+    "gateway.middleware.HTTPResponseMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = (

--- a/charts/aqueduct/files/settings.py
+++ b/charts/aqueduct/files/settings.py
@@ -445,5 +445,7 @@ LOGGING = {
 
 if TESTING:
     logger = logging.getLogger("aqueduct")
-    logging.disable(logging.NOTSET)
-    logger.setLevel(logging.DEBUG)
+    logging.disable(logging.ERROR)
+    logger.setLevel(logging.CRITICAL)
+    # logging.disable(logging.NOTSET)
+    # logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
**Main goal**

The gateway views no longer return Django `StreamingHttpResponse`/`JsonResponse` objects directly. Instead they return lightweight "raw" response objects, containing a Pydantic model or a dict as data, and a newly added `HttpResponseMiddleware` middleware converts those raw objects into real HTTP responses. (Exceptions: the two cases when there is no json in the response content: the speech endpoint, which streams bytes in a `StreamingHttpResponse`, and transcriptions with text format, which returns an `HttpResponse` with text content type.)

For streaming responses, in order to avoid repeatedly iterating over the content to apply any post-processing and then creating a new async generator, the post-processing transformations are gathered in a list (`RawStreamingResponse.transforms`) and then applied to individual chunks in the middleware. Example: `normalize_reasoning_fields()` decorator.

Note: MCP streaming responses have to yield a slightly different format of data then other streaming responses, and they do not have a `request_log` object attached, so the middleware handles them separately from the others.

The idea here is that any post-processing of the response can be now executed on a Python object, without repeatedly converting the response's content to JSON and back. The conversion happens only once, at the very end of the response handling - in the middleware.

**Other unrelated changes**
- MCP tests can now run without internet connection, providing the server package is already installed (`--prefer-offline` flag).
- Removed an unused helper method for tests (mock router).